### PR TITLE
Add harfbuzz to build inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ let
       repo = "emacs";
       inherit (repoMeta) sha256 rev;
     };
-    buildInputs = old.buildInputs ++ [ super.jansson ];
+    buildInputs = old.buildInputs ++ [ super.jansson super.harfbuzz.dev ];
     patches = [
       ./patches/tramp-detect-wrapped-gvfsd.patch
       ./patches/clean-env.patch
@@ -46,7 +46,7 @@ let
       repo = "emacs";
       inherit (repoMeta) sha256 rev;
     };
-    buildInputs = old.buildInputs ++ [ super.jansson ];
+    buildInputs = old.buildInputs ++ [ super.jansson super.harfbuzz.dev ];
     patches = [
       ./patches/tramp-detect-wrapped-gvfsd-27.patch
       ./patches/clean-env.patch


### PR DESCRIPTION
Tested on `emacsUnstable` (however `emacsGit` should also work). HarfBuzz is enabled by default on Emacs 27+ so there is no need to change build flags.

Result:
```
emacs   version    27.0.90
        features   XPM JPEG TIFF GIF PNG RSVG SOUND DBUS GSETTINGS GLIB NOTIFY INOTIFY LIBSELINUX GNUTLS LIBXML2 FREETYPE HARFBUZZ M17N_FLT LIBOTF XFT ZLIB TOOLKIT_SCROLL_BARS GTK3 X11 XDBE XIM MODULES THREADS LIBSYSTEMD JSON PDUMPER GMP
        build      abr 05, 2020
        buildopts  (--prefix=/nix/store/pwv8y5jrzlqczsnqvfyklasihap2cavw-emacs-27.0.90 --disable-build-details --with-modules --with-x-toolkit=gtk3 --with-xft CFLAGS=-DMAC_OS_X_VERSION_MAX_ALLOWED=101200)
        windowsys  x
        daemonp    server-running
```

Fix issue https://github.com/nix-community/emacs-overlay/issues/16.