### PR TITLE
Embed emacs repository revision, and branch information at build time

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,11 @@ let
       ./patches/tramp-detect-wrapped-gvfsd.patch
       ./patches/clean-env.patch
     ];
+    postPatch = ''
+       substituteInPlace lisp/loadup.el \
+         --replace '(emacs-repository-get-version)' '"${repoMeta.rev}"' \
+         --replace '(emacs-repository-get-branch)' '"master"'
+    '';
   });
 
   emacsUnstable = let


### PR DESCRIPTION
This helps with figuring out which repository revision is one running, so one can report that with their bug reports.