### PR TITLE
Reenable orgPackages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -95,14 +95,12 @@ in {
         generated = ./repos/elpa/elpa-generated.nix;
       };
 
-      # Note: Org generation is currently failing (probably a bug in emacs2nix)
-      # Comment this out when a fix has reached unstable
-      # orgPackages = esuper.orgPackages.override {
-      #   generated = ./repos/org/org-packages.nix
-      # }
+      orgPackages = esuper.orgPackages.override {
+        generated = ./repos/org/org-generated.nix;
+      };
 
       epkgs = esuper.override {
-        inherit melpaStablePackages melpaPackages elpaPackages;
+        inherit melpaStablePackages melpaPackages elpaPackages orgPackages;
       };
 
     in epkgs // {

--- a/repos/org/org-generated.nix
+++ b/repos/org/org-generated.nix
@@ -1,0 +1,33 @@
+{ callPackage }:
+  {
+    org = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "org";
+        ename = "org";
+        version = "20200511";
+        src = fetchurl {
+          url = "https://orgmode.org/elpa/org-20200511.tar";
+          sha256 = "147k6nmq00milw5knyhw01z481rcdl6s30vk4fkjidw508nkmg9c";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    org-plus-contrib = callPackage ({ elpaBuild, fetchurl, lib }:
+      elpaBuild {
+        pname = "org-plus-contrib";
+        ename = "org-plus-contrib";
+        version = "20200511";
+        src = fetchurl {
+          url = "https://orgmode.org/elpa/org-plus-contrib-20200511.tar";
+          sha256 = "1hsdp7n985404zdqj6gyfw1bxxbs0p3bf4fyizvgji21zxwnf63f";
+        };
+        packageRequires = [];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/org-plus-contrib.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+  }


### PR DESCRIPTION
This is a follow-up to https://github.com/NixOS/nixpkgs/pull/87125. org-generated.nix was generated by running `NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz ./update` (and then manually `git add`ed), so this should work fine with the cronjob.