### PR TITLE
Add emacs native-comp branch (emacsGcc)

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,6 +21,9 @@ These attributes are named =emacsGit= and =emacsUnstable=.
 Emacs from git is not guaranteed stable and may break your setup at any
 time, if it breaks you get to keep both pieces.
 
+The =feature/native-comp= branch is also provided under the attribute =emacsGcc=.
+This is to be considered highly experimental.
+
 We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies.
 

--- a/default.nix
+++ b/default.nix
@@ -58,9 +58,35 @@ let
     ];
   });
 
+  emacsGcc = let
+    repoMeta = super.lib.importJSON ./repos/emacs/emacs-feature_native-comp.json;
+  in (emacsGit.override { srcRepo = true; }).overrideAttrs(old: {
+    name = "emacs-gcc-${repoMeta.version}";
+    inherit (repoMeta) version;
+    src = super.fetchFromGitHub {
+      owner = "emacs-mirror";
+      repo = "emacs";
+      inherit (repoMeta) sha256 rev;
+    };
+
+    # When this is enabled, emacs does native compilation lazily after starting
+    # up, resulting in quicker package builds up-front, at the cost of slower
+    # running emacs until everything has been compiled. Since the elpa files in
+    # the nix store are read-only and we have binary caches, we prefer the
+    # longer AOT compilation instead of this flag.
+    # makeFlags = [ "NATIVE_FAST_BOOT=1" ];
+
+    LIBRARY_PATH = "${super.lib.getLib self.stdenv.cc.libc}/lib";
+
+    configureFlags = old.configureFlags ++ [ "--with-nativecomp" ];
+
+    buildInputs = old.buildInputs ++ [ self.libgccjit ];
+  });
 
 in {
   inherit emacsGit emacsUnstable;
+
+  inherit emacsGcc;
 
   emacsGit-nox = ((emacsGit.override {
     withX = false;

--- a/repos/emacs/emacs-feature_native-comp.json
+++ b/repos/emacs/emacs-feature_native-comp.json
@@ -1,0 +1,1 @@
+{"rev": "b619339b7a6c7952508bff72f07fc98c04e85f2c", "sha256": "0dcw8xvgncgbbq49ik45pnlqf03xggc7prh23v1ma5zy39c5rkzz", "version": "20200602.0"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -12,14 +12,15 @@ function update_repo() {
     echo $repo
 
     # Get relevant data (commit id and timestamp) for the latest commit
-    commit_data=$(curl "https://github.com/$owner/$repo/commits/master.atom" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1)
+    commit_data=$(curl "https://github.com/$owner/$repo/commits/$branch.atom" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1)
 
     # Extract commit sha and build a version number based on date: YYYYMMDD.0
     commit_sha=$(echo $commit_data | cut -d '/' -f 2)
     version_number=$(echo $commit_data | cut -d '/' -f 3 | cut -d 'T' -f 1 | sed 's/-//g').0
 
+    output_branch=$(echo $branch | sed s/"\/"/"_"/)
     digest=$(nix-prefetch-url --unpack "https://github.com/$owner/$repo/archive/${commit_sha}.tar.gz")
-    echo "{\"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > $repo-$branch.json
+    echo "{\"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > $repo-$output_branch.json
 }
 
 function update_release() {
@@ -36,6 +37,7 @@ function update_release() {
 }
 
 update_repo emacs-mirror emacs master
+update_repo emacs-mirror emacs feature/native-comp
 update_release emacs-mirror emacs unstable
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
Adds the `native-comp` branch of Emacs adding native compilation.
This is to be considered experimental and no guarantees are provided.

Closes https://github.com/nix-community/emacs-overlay/issues/29

cc @bhipple