### PR TITLE
Add emacsWithPackagesFromPackageRequires

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,8 +28,12 @@ We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies.
 
 ** Extra library functionality
-This overlay comes with an extra function to generate an Emacs closure from =use-package= declarations.
-This is an abstraction on top of =emacsWithPackages=.
+This overlay comes with extra functions to generate an Emacs closure
+from various types of dependency declaration. (These are abstractions
+on top of =emacsWithPackages=.)
+
+For example, =emacsWithPackagesFromUsePackage= adds packages which are required in a user's config via =use-package=:
+
 #+BEGIN_SRC nix
 {
   environment.systemPackages = [
@@ -49,6 +53,24 @@ This is an abstraction on top of =emacsWithPackages=.
       };
     })
   ];
+}
+#+END_SRC
+
+Similarly, =emacsWithPackagesFromPackageRequires= adds packages which
+are declared in a =.el= package file's =Package-Requires= header, which
+can be handy for CI purposes:
+
+#+BEGIN_SRC nix
+...
+let
+  emacsForCI = pkgs.emacsWithPackagesFromPackageRequires {
+    packageFile = builtins.readFile ./flycheck.el;
+    extraEmacsPackages = epkgs: [
+      epkgs.package-lint
+    ];
+  };
+pkgs.mkShell {
+  buildInputs = [ emacsForCI ];
 }
 #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -64,7 +64,7 @@ can be handy for CI purposes:
 ...
 let
   emacsForCI = pkgs.emacsWithPackagesFromPackageRequires {
-    packageFile = builtins.readFile ./flycheck.el;
+    packageElisp = builtins.readFile ./flycheck.el;
     extraEmacsPackages = epkgs: [
       epkgs.package-lint
     ];

--- a/default.nix
+++ b/default.nix
@@ -82,7 +82,6 @@ let
 
     buildInputs = old.buildInputs ++ [ self.libgccjit ];
   });
-
 in {
   inherit emacsGit emacsUnstable;
 
@@ -105,6 +104,8 @@ in {
   }));
 
   emacsWithPackagesFromUsePackage = import ./elisp.nix { pkgs = self; };
+
+  emacsWithPackagesFromPackageRequires = import ./packreq.nix { pkgs = self; };
 
   emacsPackagesFor = emacs: (
     (super.emacsPackagesFor emacs).overrideScope'(eself: esuper: let

--- a/elisp.nix
+++ b/elisp.nix
@@ -6,35 +6,14 @@ use-package declarations.
 { pkgs }:
 
 let
-  isStrEmpty = s: (builtins.replaceStrings [" "] [""] s) == "";
-
-  splitString = _sep: _s: builtins.filter
-    (x: builtins.typeOf x == "string")
-    (builtins.split _sep _s);
-
-  stripComments = dotEmacs: let
-    lines = splitString "\n" dotEmacs;
-    stripped = builtins.map (l:
-      builtins.elemAt (splitString ";;" l) 0) lines;
-  in builtins.concatStringsSep " " stripped;
-
-  parsePackages = dotEmacs: let
-    strippedComments = stripComments dotEmacs;
-    tokens = builtins.filter (t: !(isStrEmpty t)) (builtins.map
-      (t: if builtins.typeOf t == "list" then builtins.elemAt t 0 else t)
-      (builtins.split "([\(\)])" strippedComments));
-    matches = builtins.map (t:
-      builtins.match "^use-package[[:space:]]+([A-Za-z0-9_-]+).*" t) tokens;
-  in builtins.map (m: builtins.elemAt m 0)
-      (builtins.filter (m: m != null) matches);
-
+  parse = pkgs.callPackage ./parse.nix {};
 in {
   config,
   extraEmacsPackages ? epkgs: [],
   package ? pkgs.emacs,
   override ? (epkgs: epkgs)
 }: let
-  packages = parsePackages config;
+  packages = parse.parsePackagesFromUsePackage config;
   emacsPackages = pkgs.emacsPackagesGen package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 in emacsWithPackages (epkgs: let

--- a/packreq.nix
+++ b/packreq.nix
@@ -7,13 +7,13 @@ Package-Requires declarations.
 let
   parse = pkgs.callPackage ./parse.nix { };
 in
-{ packageFile
+{ packageElisp
 , extraEmacsPackages ? epkgs: [ ]
 , package ? pkgs.emacs
 , override ? (epkgs: epkgs)
 }:
 let
-  packages = parse.parsePackagesFromPackageRequires packageFile;
+  packages = parse.parsePackagesFromPackageRequires packageElisp;
   emacsPackages = pkgs.emacsPackagesGen package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 in

--- a/packreq.nix
+++ b/packreq.nix
@@ -1,0 +1,26 @@
+/*
+Parse an emacs package file to derive packages from
+Package-Requires declarations.
+*/
+
+{ pkgs }:
+let
+  parse = pkgs.callPackage ./parse.nix { };
+in
+{ packageFile
+, extraEmacsPackages ? epkgs: [ ]
+, package ? pkgs.emacs
+, override ? (epkgs: epkgs)
+}:
+let
+  packages = parse.parsePackagesFromPackageRequires packageFile;
+  emacsPackages = pkgs.emacsPackagesGen package;
+  emacsWithPackages = emacsPackages.emacsWithPackages;
+in
+emacsWithPackages (epkgs:
+  let
+    overriden = override epkgs;
+    usePkgs = builtins.map (name: overriden.${name}) packages;
+    extraPkgs = extraEmacsPackages overriden;
+  in
+  [ overriden.use-package ] ++ usePkgs ++ extraPkgs)

--- a/parse.nix
+++ b/parse.nix
@@ -12,11 +12,11 @@ let
       requires =
         lib.concatMapStrings
           (line:
-            let match = builtins.match "^;;;* *[pP]ackage-[rR]equires *: *\\((.*)\\)" line;
+            let match = builtins.match ";;;* *[pP]ackage-[rR]equires *: *\\((.*)\\) *" line;
             in if match == null then "" else builtins.head match)
           lines;
       parseReqList = s:
-        let matchAndRest = builtins.match " *\\(? *([^ \"\\)]+)( +\"[^\"]+\" *\\))?(.*)" s;
+        let matchAndRest = builtins.match " *\\(? *([^ \"\\)]+)( +\"[^\"]+\" *\\)| *\\))?(.*)" s;
         in
         if isStrEmpty s then
           [ ]

--- a/parse.nix
+++ b/parse.nix
@@ -1,0 +1,61 @@
+{ lib }:
+let
+  isStrEmpty = s: (builtins.replaceStrings [ " " ] [ "" ] s) == "";
+
+  splitString = _sep: _s: builtins.filter
+    (x: builtins.typeOf x == "string")
+    (builtins.split _sep _s);
+
+  parsePackagesFromPackageRequires = packageFile:
+    let
+      lines = splitString "\r?\n" packageFile;
+      requires =
+        lib.concatMapStrings
+          (line:
+            let match = builtins.match "^;;;* *[pP]ackage-[rR]equires *: *\\((.*)\\)" line;
+            in if match == null then "" else builtins.head match)
+          lines;
+      parseReqList = s:
+        let matchAndRest = builtins.match " *\\(? *([^ \"\\)]+)( +\"[^\"]+\" *\\))?(.*)" s;
+        in
+        if isStrEmpty s then
+          [ ]
+        else
+          if matchAndRest == null then
+            throw "Failed to parse package requirements list: ${s}"
+          else
+            [ (builtins.head matchAndRest) ] ++ (parseReqList (builtins.elemAt matchAndRest 2));
+    in
+    parseReqList requires;
+
+  stripComments = dotEmacs:
+    let
+      lines = splitString "\n" dotEmacs;
+      stripped = builtins.map
+        (l:
+          builtins.elemAt (splitString ";;" l) 0)
+        lines;
+    in
+    builtins.concatStringsSep " " stripped;
+
+  parsePackagesFromUsePackage = dotEmacs:
+    let
+      strippedComments = stripComments dotEmacs;
+      tokens = builtins.filter (t: !(isStrEmpty t)) (builtins.map
+        (t: if builtins.typeOf t == "list" then builtins.elemAt t 0 else t)
+        (builtins.split "([\(\)])" strippedComments)
+      );
+      matches = builtins.map
+        (t:
+          builtins.match "^use-package[[:space:]]+([A-Za-z0-9_-]+).*" t)
+        tokens;
+    in
+    builtins.map
+      (m: builtins.elemAt m 0)
+      (builtins.filter (m: m != null) matches);
+
+in
+{
+  inherit parsePackagesFromPackageRequires;
+  inherit parsePackagesFromUsePackage;
+}

--- a/parse.nix
+++ b/parse.nix
@@ -6,6 +6,19 @@ let
     (x: builtins.typeOf x == "string")
     (builtins.split _sep _s);
 
+  # Parse (all) Package-Requires elisp headers found in the input string
+  # `packageFile` into a list of package name strings.
+  #
+  # Example inputs:
+  #
+  #  ;; Package-Requires: ()
+  #  => [ ]
+  #  ;; Package-Requires: ((dash "2.12.1") (pkg-info "0.4") (let-alist "1.0.4") (seq "1.11") (emacs "24.3"))
+  #  => [ "dash" "pkg-info" "let-alist" "seq" "emacs" ]
+  #  ;; Package-Requires: (dash (pkg-info "0.4"))
+  #  => [ "dash" "pkg-info" ]
+  #  ;; Package-Requires: ((dash) (pkg-info "0.4"))
+  #  => [ "dash" "pkg-info" ]
   parsePackagesFromPackageRequires = packageFile:
     let
       lines = splitString "\r?\n" packageFile;

--- a/parse.nix
+++ b/parse.nix
@@ -6,8 +6,8 @@ let
     (x: builtins.typeOf x == "string")
     (builtins.split _sep _s);
 
-  # Parse (all) Package-Requires elisp headers found in the input string
-  # `packageFile` into a list of package name strings.
+  # Parse (all) Package-Requires packageElisp headers found in the input string
+  # `packageElisp` into a list of package name strings.
   #
   # Example inputs:
   #
@@ -19,9 +19,9 @@ let
   #  => [ "dash" "pkg-info" ]
   #  ;; Package-Requires: ((dash) (pkg-info "0.4"))
   #  => [ "dash" "pkg-info" ]
-  parsePackagesFromPackageRequires = packageFile:
+  parsePackagesFromPackageRequires = packageElisp:
     let
-      lines = splitString "\r?\n" packageFile;
+      lines = splitString "\r?\n" packageElisp;
       requires =
         lib.concatMapStrings
           (line:


### PR DESCRIPTION
This provides a mechanism for creating an Emacs closure that contains the runtime dependencies for a given Emacs package source file, by inspecting its `Package-Requires` header.

I wanted to explore using emacs-overlay to simplify the process of provisioning tailored Emacsen for testing packages in CI and locally, as an alternative to using/integrating with Cask: this is the result, and I'm quite excited about it. Further work could add support for parsing `-pkg.el` files, or even `Cask` files, though it's pretty annoying to use `builtins.*` to dig through sexps.

There's an opportunity to somewhat unify the interface between the functions in `elisp.nix` and `packreq.nix`, but it wasn't immediately clear how best to factor that to avoid it getting clunky or unnatural, so I thought I'd post this here for thoughts.