### PR TITLE
emacsUnstable: Re-add jansson/harfbuzz.dev

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ let
       repo = "emacs";
       inherit (repoMeta) sha256 rev;
     };
+    buildInputs = old.buildInputs ++ [ super.jansson super.harfbuzz.dev ];
     patches = [
       ./patches/tramp-detect-wrapped-gvfsd-27.patch
       ./patches/clean-env.patch


### PR DESCRIPTION
They were removed in commit b74dbf73ecf7cc420740c87af4c2d113d1fdd58e, I think by mistake.

Thanks to them being missing, there are some performance issues when using LSP (a heavy user of json). Also, we were using an outdated font rendering that was deprecated in Emacs 27.

This PR should fix those two issues.