### PR TITLE
Add --with-cairo for NixOS stable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,7 @@ let
         '';
       } // super.lib.optionalAttrs isStable {
         buildInputs = old.buildInputs ++ [
+          super.cairo
           super.harfbuzz.dev
           super.jansson
         ];
@@ -59,6 +60,8 @@ let
   };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json).overrideAttrs(old: {
+    configureFlags = old.configureFlags ++ [ "--with-cairo" ];
+
     patches = [
       ./patches/tramp-detect-wrapped-gvfsd-27.patch
       ./patches/clean-env.patch


### PR DESCRIPTION
In `release-20.03`, `cairo` is only used if OS is macOS: https://github.com/NixOS/nixpkgs/blob/release-20.03/pkgs/applications/editors/emacs/default.nix#L69

In `master`, it is used everywhere: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/emacs/default.nix#L94

But `--with-cairo` option is no longer experimental in `27.1`: https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.27#L53-L59. So this PR enable `cairo` regardless of OS, allowing NixOS to build Emacs with `cairo`. Also, it adds `--with-cairo` for `emacsUnstable` since it is not enabled by default (allowing both NixOS and macOS to build support with `cairo` in `emacsUnstable`). In `emacsGit` it should work anyway since `--with-cairo` is the default: https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS#L27-L32

**Before**
```
Configured for 'x86_64-pc-linux-gnu'.

...
  Does Emacs use cairo?                                   no
...
```

**After**
```
Configured for 'x86_64-pc-linux-gnu'.

...
  Does Emacs use cairo?                                   yes
...
```