### PR TITLE
Add `alwaysTangle` argument to emacsWithPackagesFromUsePackage

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,28 +35,48 @@ on top of =emacsWithPackages=.)
 For example, =emacsWithPackagesFromUsePackage= adds packages which are required in a user's config via =use-package=:
 
 #+BEGIN_SRC nix
-{
-  environment.systemPackages = [
-    (emacsWithPackagesFromUsePackage {
-      config = builtins.readFile ./emacs.el;
-      # Package is optional, defaults to pkgs.emacs
-      package = pkgs.emacsGit;
-      # By default emacsWithPackagesFromUsePackage will only pull in packages with `:ensure t`.
-      # Setting alwaysEnsure to true emulates `use-package-always-ensure` and pulls in all use-package references.
-      alwaysEnsure = true;
-      # Optionally provide extra packages not in the configuration file
-      extraEmacsPackages = epkgs: [
-        epkgs.cask
-      ];
-      # Optionally override derivations
-      override = epkgs: epkgs // {
-        weechat = epkgs.melpaPackages.weechat.overrideAttrs(old: {
-          patches = [ ./weechat-el.patch ];
-        });
-      };
-    })
-  ];
-}
+  {
+    environment.systemPackages = [
+      (emacsWithPackagesFromUsePackage {
+        # Your Emacs config file. Org mode babel files are also supported.
+        # config = ./emacs.org;
+        config = ./emacs.el;
+
+        # Package is optional, defaults to pkgs.emacs
+        package = pkgs.emacsGit;
+
+        # By default emacsWithPackagesFromUsePackage will only pull in
+        # packages with `:ensure`, `:ensure t` or `:ensure <package name>`.
+        # Setting `alwaysEnsure` to `true` emulates `use-package-always-ensure`
+        # and pulls in all use-package references not explicitly disabled via
+        # `:ensure nil` or `:disabled`.
+        # Note that this is NOT recommended unless you've actually set
+        # `use-package-always-ensure` to `t` in your config.
+        alwaysEnsure = true;
+
+        # For Org mode babel files, by default only code blocks with
+        # `:tangle yes` are considered. Setting `alwaysTangle` to `true`
+        # will include all code blocks missing the `:tangle` argument,
+        # defaulting it to `yes`.
+        # Note that this is NOT recommended unless you have something like
+        # `#+PROPERTY: header-args:emacs-lisp :tangle yes` in your config,
+        # which defaults `:tangle` to `yes`.
+        alwaysTangle = true;
+
+        # Optionally provide extra packages not in the configuration file.
+        extraEmacsPackages = epkgs: [
+          epkgs.cask
+        ];
+
+        # Optionally override derivations.
+        override = epkgs: epkgs // {
+          weechat = epkgs.melpaPackages.weechat.overrideAttrs(old: {
+            patches = [ ./weechat-el.patch ];
+          });
+        };
+      })
+    ];
+  }
 #+END_SRC
 
 Similarly, =emacsWithPackagesFromPackageRequires= adds packages which

--- a/elisp.nix
+++ b/elisp.nix
@@ -14,6 +14,8 @@ in
 { config
 # emulate `use-package-always-ensure` behavior
 , alwaysEnsure ? false
+# emulate `#+PROPERTY: header-args:emacs-lisp :tangle yes`
+, alwaysTangle ? false
 , extraEmacsPackages ? epkgs: [ ]
 , package ? pkgs.emacs
 , override ? (epkgs: epkgs)
@@ -46,7 +48,7 @@ let
       else throw "Unsupported type for config: \"${type}\"";
 
   packages = showNotice (parse.parsePackagesFromUsePackage {
-    inherit configText alwaysEnsure isOrgModeFile;
+    inherit configText alwaysEnsure isOrgModeFile alwaysTangle;
   });
   emacsPackages = pkgs.emacsPackagesGen package;
   emacsWithPackages = emacsPackages.emacsWithPackages;

--- a/parse.nix
+++ b/parse.nix
@@ -1,7 +1,7 @@
 { pkgs, lib }:
 
 let
-  inherit (import ./repos/fromElisp { inherit pkgs; }) fromElisp fromOrgModeBabelElisp;
+  inherit (import ./repos/fromElisp { inherit pkgs; }) fromElisp fromOrgModeBabelElisp';
 
   isStrEmpty = s: (builtins.replaceStrings [ " " ] [ "" ] s) == "";
 
@@ -70,14 +70,15 @@ let
   # ''
   # => [ "direnv" "paredit" ]
   parsePackagesFromUsePackage = {
-    configText,
-    alwaysEnsure ? false,
-    isOrgModeFile ? false
+    configText
+    , alwaysEnsure ? false
+    , isOrgModeFile ? false
+    , alwaysTangle ? false
   }:
     let
       readFunction =
         if isOrgModeFile then
-          fromOrgModeBabelElisp
+          fromOrgModeBabelElisp' { ":tangle" = if alwaysTangle then "yes" else "no"; }
         else
           fromElisp;
 


### PR DESCRIPTION
Add an option to tangle Org babel code blocks by default, as suggested in #52. `fromElisp` has also been updated to support `#+HEADER:`-lines.

cc @alexvorobiev @terlar