### PR TITLE
Add support for PGTK and PGTK + native comp forks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,9 +39,7 @@ let
               name = "${namePrefix}-${repoMeta.version}";
               inherit (repoMeta) version;
               src = super.fetchFromGitHub {
-                owner = "emacs-mirror";
-                repo = "emacs";
-                inherit (repoMeta) sha256 rev;
+                inherit (repoMeta) owner repo sha256 rev;
               };
 
               patches = [

--- a/default.nix
+++ b/default.nix
@@ -81,9 +81,22 @@ let
         )
       ];
 
+  mkPgtkEmacs = namePrefix: jsonFile: (mkGitEmacs namePrefix jsonFile).overrideAttrs (
+    old: {
+      configureFlags = (super.lib.remove "--with-xft" old.configureFlags)
+        ++ super.lib.singleton "--with-pgtk";
+    }
+  );
+
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json;
 
   emacsGcc = (mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-feature_native-comp.json).override {
+    nativeComp = true;
+  };
+
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-pgtk.json;
+
+  emacsPgtkGcc = (mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-pgtk-nativecomp.json).override {
     nativeComp = true;
   };
 
@@ -101,6 +114,8 @@ in
   inherit emacsGit emacsUnstable;
 
   inherit emacsGcc;
+
+  inherit emacsPgtk emacsPgtkGcc;
 
   emacsGit-nox = (
     (

--- a/repos/emacs/emacs-feature_native-comp.json
+++ b/repos/emacs/emacs-feature_native-comp.json
@@ -1,1 +1,1 @@
-{"rev": "e20cdf937e74ebcaa2c6dabb63be1c20a6ea44f6", "sha256": "1hfavsr8ci5sdhhgd97k3v0s40909fhmdj9xbrkyqp7b9liw1m6p", "version": "20201108.0"}
+{"owner": "emacs-mirror", "repo": "emacs", "rev": "e20cdf937e74ebcaa2c6dabb63be1c20a6ea44f6", "sha256": "1hfavsr8ci5sdhhgd97k3v0s40909fhmdj9xbrkyqp7b9liw1m6p", "version": "20201108.0"}

--- a/repos/emacs/emacs-master.json
+++ b/repos/emacs/emacs-master.json
@@ -1,1 +1,1 @@
-{"rev": "bffd5d3a9d44ed99d6a573dc0fabe542d6b3bb8b", "sha256": "0a15k48x42yqd1y8j3anxwc43r863ngwip8mfcr75nzhybz4if6j", "version": "20201109.0"}
+{"owner": "emacs-mirror", "repo": "emacs", "rev": "575b0681d926463960fc00d1e33decaa71d5c956", "sha256": "05lcakcqfp6p992f615ncckngs8w2znrdz9z0jhy8rpi0hsz6m6l", "version": "20201109.0"}

--- a/repos/emacs/emacs-pgtk-nativecomp.json
+++ b/repos/emacs/emacs-pgtk-nativecomp.json
@@ -1,0 +1,1 @@
+{"owner": "flatwhatson", "repo": "emacs", "rev": "d3bd0f477f81da084d061a3b21f13a06fa9b9206", "sha256": "1s7k00lzdl3s75jgs3qypfsilz0s3n2n2brk2v89ydjzbr51xina", "version": "20201108.0"}

--- a/repos/emacs/emacs-pgtk.json
+++ b/repos/emacs/emacs-pgtk.json
@@ -1,0 +1,1 @@
+{"owner": "masm11", "repo": "emacs", "rev": "9c7750758271139c55313e6e153c94d30123a6cc", "sha256": "1vkmrbvzpmhv3qfkd846awhcikjl7v7znmq66bm9zz74h7vx5v10", "version": "20201108.0"}

--- a/repos/emacs/emacs-unstable.json
+++ b/repos/emacs/emacs-unstable.json
@@ -1,1 +1,1 @@
-{"rev": "emacs-27.1", "sha256": "1i50ksf96fxa3ymdb1irpc82vi67861sr4xlcmh9f64qw9imm3ks", "version": "emacs-27.1"}
+{"owner": "emacs-mirror", "repo": "emacs", "rev": "emacs-27.1", "sha256": "1i50ksf96fxa3ymdb1irpc82vi67861sr4xlcmh9f64qw9imm3ks", "version": "emacs-27.1"}

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -9,4 +9,6 @@ let
 in {
   emacsUnstable = mkTestBuild pkgs.emacsUnstable;
   emacsGit = mkTestBuild pkgs.emacsGit;
+  emacsPgtk = mkTestBuild pkgs.emacsPgtk;
+  emacsPgtkGcc = mkTestBuild pkgs.emacsPgtkGcc;
 }

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -20,7 +20,7 @@ function update_repo() {
 
     output_branch=$(echo $branch | sed s/"\/"/"_"/)
     digest=$(nix-prefetch-url --unpack "https://github.com/$owner/$repo/archive/${commit_sha}.tar.gz")
-    echo "{\"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > $repo-$output_branch.json
+    echo "{\"owner\": \"${owner}\", \"repo\": \"${repo}\", \"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > $repo-$output_branch.json
 }
 
 function update_release() {
@@ -33,7 +33,7 @@ function update_release() {
 
     digest=$(nix-prefetch-url --unpack "https://github.com/$owner/$repo/archive/${tag}.tar.gz")
 
-    echo "{\"rev\": \"${tag}\", \"sha256\": \"${digest}\", \"version\": \"${tag}\"}" > $repo-$branch.json
+    echo "{\"owner\": \"${owner}\", \"repo\": \"${repo}\", \"rev\": \"${tag}\", \"sha256\": \"${digest}\", \"version\": \"${tag}\"}" > $repo-$branch.json
 }
 
 update_repo emacs-mirror emacs master

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -38,6 +38,8 @@ function update_release() {
 
 update_repo emacs-mirror emacs master
 update_repo emacs-mirror emacs feature/native-comp
+update_repo masm11 emacs pgtk
+update_repo flatwhatson emacs pgtk-nativecomp
 update_release emacs-mirror emacs unstable
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
This adds support for the pure GTK (runs on Wayland without XWayland) fork which has been gaining popularity. This fork does not have the native comp changes so there is another fork which combines these two. Hopefully the PGTK fork is upstreamed but unlikely in the near future. That's why I thought it might be useful to include here.