### PR TITLE
ci: Update nixpkgs URL, nixpkgs-channels -> nixpkgs

### DIFF
--- a/.ci/cron
+++ b/.ci/cron
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Note: This script is executed from git root
-export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
+export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz
 
 if [ $CI_PIPELINE_SOURCE != "schedule" ] && [ $CI_PIPELINE_SOURCE != "web" ]; then
     echo "Only scheduled or manual jobs will run, consider successful"


### PR DESCRIPTION
The `nixpkgs-channels` repo is deprecated and no longer updated.

Fixes #78 