### PR TITLE
Stop using deprecated "nixpkgs-channels" repo (again)

### DIFF
--- a/hydra/default.nix
+++ b/hydra/default.nix
@@ -26,7 +26,7 @@ let
       };
       nixpkgs = {
         type = "git";
-        value = "git://github.com/NixOS/nixpkgs-channels.git ${nixpkgsRelease}";
+        value = "git://github.com/NixOS/nixpkgs.git ${nixpkgsRelease}";
         emailresponsible = false;
       };
     };

--- a/hydra/spec.json
+++ b/hydra/spec.json
@@ -18,7 +18,7 @@
     },
     "nixpkgs": {
       "type": "git",
-      "value": "git://github.com/NixOS/nixpkgs-channels.git nixos-unstable",
+      "value": "git://github.com/NixOS/nixpkgs.git nixos-unstable",
       "emailresponsible": false
     }
   }


### PR DESCRIPTION
Looks like these were missed in an earlier commit. See issue #78.