### PR TITLE
Allow `leaf` to be used as an alternative to `use-package` in `emacsWithPackagesFromUsePackage`

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ from various types of dependency declaration. (These are abstractions
 on top of =emacsWithPackages=.)
 
 For example, =emacsWithPackagesFromUsePackage= adds packages which are
-required in a user's config via =use-package=:
+required in a user's config via =use-package= or =leaf=.
 
 #+BEGIN_SRC nix
   {

--- a/elisp.nix
+++ b/elisp.nix
@@ -64,4 +64,4 @@ emacsWithPackages (epkgs:
     usePkgs = map (name: overridden.${name} or (mkPackageError name)) packages;
     extraPkgs = extraEmacsPackages overridden;
   in
-  [ overridden.use-package ] ++ usePkgs ++ extraPkgs)
+  usePkgs ++ extraPkgs)

--- a/parse.nix
+++ b/parse.nix
@@ -134,13 +134,16 @@ let
 
       recurse = item:
         if builtins.isList item && item != [] then
-          if (builtins.head item) == "use-package" then
-            if !(isDisabled item) then
-              [ (getName item) ] ++ map recurse item
+          let
+            packageManager = builtins.head item;
+          in
+            if builtins.elem packageManager [ "use-package" "leaf" ] then
+              if !(isDisabled item) then
+                [ packageManager (getName item) ] ++ map recurse item
+              else
+                []
             else
-              []
-          else
-            map recurse item
+              map recurse item
         else
           [];
     in


### PR DESCRIPTION
Add [`leaf`](https://github.com/conao3/leaf.el) as an alternative to `use-package` in `emacsWithPackagesFromUsePackage`. Automatically add the used package manager(s) to the package set.

Alternative to #82.

cc @adithyaov