### PR TITLE
emacs-unstable: update tramp-gvfs patch

### DIFF
--- a/patches/tramp-detect-wrapped-gvfsd-27.patch
+++ b/patches/tramp-detect-wrapped-gvfsd-27.patch
@@ -1,11 +1,11 @@
 diff --git a/lisp/net/tramp-gvfs.el b/lisp/net/tramp-gvfs.el
-index 34a234c..b5a471c 100644
+index b457f54fd5..b0a9563b76 100644
 --- a/lisp/net/tramp-gvfs.el
 +++ b/lisp/net/tramp-gvfs.el
-@@ -122,6 +122,7 @@
- 	 (tramp-compat-funcall 'dbus-get-unique-name :system)
- 	 (tramp-compat-funcall 'dbus-get-unique-name :session)
- 	 (or (tramp-compat-process-running-p "gvfs-fuse-daemon")
+@@ -125,6 +125,7 @@
+ 	     ;; for some processes.  Better we don't check.
+ 	     (<= emacs-major-version 25)
+ 	     (tramp-compat-process-running-p "gvfs-fuse-daemon")
 +	     (tramp-compat-process-running-p ".gvfsd-fuse-wrapped")
  	     (tramp-compat-process-running-p "gvfsd-fuse"))))
    "Non-nil when GVFS is available.")


### PR DESCRIPTION
emacs 27.1.90 was released, and tramp-gvfs.c was updated. This should fix #93.