### PR TITLE
mkGitEmacs: make composable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ let
     in
     builtins.foldl'
       (drv: fn: fn drv)
-      self.emacs
+      super.emacs
       [
 
         (drv: drv.override { srcRepo = true; })


### PR DESCRIPTION
Was unable to override `emacs`. This probably causes a different issue with which `emacs` is used since it relies more on the order of the composition of overlays. 