### PR TITLE
use overrideAttrs' argument instead of referring to derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,8 +88,8 @@ let
         # reconnect pkgs to the built emacs
         (
           drv: let
-            result = drv.overrideAttrs (_: {
-              passthru = drv.passthru // {
+            result = drv.overrideAttrs (old: {
+              passthru = old.passthru // {
                 pkgs = self.emacsPackagesFor result;
               };
             });


### PR DESCRIPTION
I don't exactly understand why, but this fixes native compilation of packages for me. See https://github.com/nix-community/emacs-overlay/pull/105#issuecomment-770427371.