### PR TITLE
emacs-unstable: Change rev from emacs-27.2-rc2 to emacs-27.2

### DIFF
--- a/repos/emacs/emacs-unstable.json
+++ b/repos/emacs/emacs-unstable.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "emacs-27.2-rc2", "sha256": "0p5ilxpn9kj57h9fbw3jwz409k5j1ilpyj7z3i3crxs7aigiga8s", "version": "27.2"}
+{"type": "savannah", "repo": "emacs", "rev": "emacs-27.2", "sha256": "0p5ilxpn9kj57h9fbw3jwz409k5j1ilpyj7z3i3crxs7aigiga8s", "version": "27.2"}


### PR DESCRIPTION
The sha256 doesn't change because 27.2-rc2 is actually the same as
27.2.