### PR TITLE
Update that native-comp was merged in master

### DIFF
--- a/README.org
+++ b/README.org
@@ -56,8 +56,8 @@ These attributes are named =emacsGit= and =emacsUnstable=.
 Emacs from git is not guaranteed stable and may break your setup at any
 time, if it breaks you get to keep both pieces.
 
-The =feature/native-comp= branch is also provided under the attribute =emacsGcc=.
-This is to be considered highly experimental.
+Furthermore we provide emacs compiled with the native compilation backend enabled
+under the attribute =emacsGcc=.
 
 We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies, as well as the

--- a/default.nix
+++ b/default.nix
@@ -87,11 +87,11 @@ let
 
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
 
-  emacsGcc = (mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-feature_native-comp.json { nativeComp = true; });
+  emacsGcc = mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-master.json { nativeComp = true; };
 
   emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-feature_pgtk.json { };
 
-  emacsPgtkGcc = (mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-pgtk-nativecomp.json { nativeComp = true; });
+  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-feature_pgtk.json { nativeComp = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { }).overrideAttrs (
     old: {

--- a/repos/emacs/emacs-feature_native-comp.json
+++ b/repos/emacs/emacs-feature_native-comp.json
@@ -1,1 +1,0 @@
-{"type": "savannah", "repo": "emacs", "rev": "fa65c044f2ebe666467166075c1507a8d0e1347f", "sha256": "04i11mxn3qy98sz5a4iq0vb1qk3h7bqqs5bp4nxk5hn12bb4i6j9", "version": "20210424.0"}

--- a/repos/emacs/emacs-pgtk-nativecomp.json
+++ b/repos/emacs/emacs-pgtk-nativecomp.json
@@ -1,1 +1,0 @@
-{"type": "github", "owner": "flatwhatson", "repo": "emacs", "rev": "b94a57e4856e94444606f86a5ee18c5acfca34ec", "sha256": "1h21vgzr2ib6x62z1c85d937ciq2l3x4sn20vm3ndfj7bycinl3b", "version": "20210429.0"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -53,9 +53,7 @@ function update_release() {
 }
 
 update_savannah_branch master
-update_savannah_branch feature/native-comp
 update_savannah_branch feature/pgtk
-update_github_repo flatwhatson emacs pgtk-nativecomp
 update_release
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
The native compilation branch was recently merged into master. This PR address this change (and therefore fixes #141).