### PR TITLE
stable nixpkgsRelease: 20.09->21.05

### DIFF
--- a/hydra/default.nix
+++ b/hydra/default.nix
@@ -41,7 +41,7 @@ let
     };
 
     stable = mkJobset {
-      nixpkgsRelease = "nixos-20.09";
+      nixpkgsRelease = "nixos-21.05";
       nixFile = "emacsen.nix";
       descriptionNote = "emacs";
     };


### PR DESCRIPTION
Right now, one has no cache for the nixos stable channel that was recently changed to 21.05, I hope this fixes that.