### PR TITLE
mkExDrv: properly pass commit as required by recent package-build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,8 @@ let
         pname = name;
         ename = name;
         version = repoMeta.version;
+        commit = repoMeta.rev;
+
         recipe = builtins.toFile "recipe" ''
           (${name} :fetcher github
           :repo "ch11ng/${name}")


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/9140d4b06ff09bce8dd8e384eeef832e7811d288
broke certain builds that were not properly passing commit as an
argument to the builder. This also caused the exwm xelb (i. e.
emacsPackages.xelb) to fail. Since we have the commit as
`repoMeta.rev` anyways, passing it properly is trivial.