### PR TITLE
* repos/emacs/update: fetch more commits in git clone

### DIFF
--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -42,7 +42,7 @@ function update_github_repo() {
 function update_release() {
     echo emacs release
 
-    git clone --shallow-since="$(date --date='-6 month')" https://git.savannah.gnu.org/git/emacs.git emacs_git_repo
+    git clone --shallow-since="$(date --date='-9 month')" https://git.savannah.gnu.org/git/emacs.git emacs_git_repo
     tag=$(git -C emacs_git_repo tag -l --sort=-v:refname 'emacs-*' | grep -v '\-rc' | head -n1)
     rm -rf emacs_git_repo
 


### PR DESCRIPTION
If more than the specified amount of time has passed, then there is no
tag, and nothing actually gets downloaded by `nix-prefetch-url`.

In this case, slightly more than 6 months (the previously specified time) have passed since the release of 27.2, so the build fails to get any release version, which is why no updates to Emacs have occurred here since last week.

28.0.91 should come out soon, so I think 9 months may be appropriate.

cc @talyz