### PR TITLE
Make emacsUnstable build Emacs 28

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -95,10 +95,10 @@ let
 
   emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-feature_pgtk.json { nativeComp = true; };
 
-  emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { }).overrideAttrs (
+  emacsUnstable = (mkPgtkEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { nativeComp = true; }).overrideAttrs (
     old: {
       patches = [
-        ./patches/tramp-detect-wrapped-gvfsd-27.patch
+        ./patches/tramp-detect-wrapped-gvfsd-28.patch
       ];
     }
   );

--- a/patches/tramp-detect-wrapped-gvfsd-28.patch
+++ b/patches/tramp-detect-wrapped-gvfsd-28.patch
@@ -1,0 +1,10 @@
+--- a/lisp/net/tramp-gvfs.el	1970-01-01 01:00:01.000000000 +0100
++++ b/lisp/net/tramp-gvfs.el	2021-11-19 10:07:59.103082296 +0100
+@@ -126,6 +126,7 @@
+ 	     ;; for some processes.  Better we don't check.
+ 	     (<= emacs-major-version 25)
+ 	     (tramp-process-running-p "gvfs-fuse-daemon")
++             (tramp-process-running-p ".gvfsd-fuse-wrapped")
+ 	     (tramp-process-running-p "gvfsd-fuse"))))
+   "Non-nil when GVFS is available.")
+ 

--- a/repos/emacs/emacs-unstable.json
+++ b/repos/emacs/emacs-unstable.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "emacs-27.2", "sha256": "0p5ilxpn9kj57h9fbw3jwz409k5j1ilpyj7z3i3crxs7aigiga8s", "version": "27.2"}
+{"type": "savannah", "repo": "emacs", "rev": "emacs-28", "sha256": "1g4qf1wfnla5h3l5qbgpyk0hlhd735my7882slx9xxdg41xdcrjs", "version": "28"}


### PR DESCRIPTION
The emacsUnstable derivation is supposed to be updated automatically when Emacs 28 RC1 is released. Nevertheless, my experiments tend to show that it won't build because the gvfsd patch won't apply. In this PR, I added a patch for gvfsd on Emacs 28 so maintainers of emacs-overlay can cherry-pick it (and close this PR).