### PR TITLE
Add emacs 28

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -95,6 +95,18 @@ let
 
   emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-feature_pgtk.json { nativeComp = true; };
 
+  emacsGcc28 = (mkGitEmacs "emacs-gcc-28" ./repos/emacs/emacs-emacs-28.json { nativeComp = true; }).overrideAttrs (
+    old: {
+      patches = [ ./patches/tramp-detect-wrapped-gvfsd-28.patch ];
+    });
+
+  emacs28 = (mkGitEmacs "emacs-gcc-28" ./repos/emacs/emacs-emacs-28.json { }).overrideAttrs (
+    old: {
+      patches = [
+        ./patches/tramp-detect-wrapped-gvfsd-28.patch
+      ];
+    });
+
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { }).overrideAttrs (
     old: {
       patches = [
@@ -106,6 +118,8 @@ let
 in
 {
   inherit emacsGit emacsUnstable;
+
+  inherit emacs28 emacsGcc28;
 
   inherit emacsGcc;
 

--- a/patches/tramp-detect-wrapped-gvfsd-28.patch
+++ b/patches/tramp-detect-wrapped-gvfsd-28.patch
@@ -1,0 +1,12 @@
+diff --git a/lisp/net/tramp-gvfs.el b/lisp/net/tramp-gvfs.el
+index 1722c53b..fc5866b9 100644
+--- a/lisp/net/tramp-gvfs.el
++++ b/lisp/net/tramp-gvfs.el
+@@ -126,6 +126,7 @@
+ 	     ;; for some processes.  Better we don't check.
+ 	     (<= emacs-major-version 25)
+ 	     (tramp-process-running-p "gvfs-fuse-daemon")
++	     (tramp-process-running-p ".gvfsd-fuse-wrapped")
+ 	     (tramp-process-running-p "gvfsd-fuse"))))
+   "Non-nil when GVFS is available.")
+ 

--- a/repos/emacs/emacs-emacs-28.json
+++ b/repos/emacs/emacs-emacs-28.json
@@ -1,0 +1,1 @@
+{"type": "savannah", "repo": "emacs", "rev": "756b8a5f1bd28aeadc804fd2f93ce7e823a1d4a2", "sha256": "05ms14p0v2zl86dii72062z8fy842fvwrxqw5kbfrxxa0d7szb5p", "version": "20211123.0"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -54,6 +54,7 @@ function update_release() {
 
 update_savannah_branch master
 update_savannah_branch feature/pgtk
+update_savannah_branch emacs-28
 update_release
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
As the release branch for emacs 28 has been cut, and emacsGit now builds emacs
29, let's add a way to track emacs 28.

This is very similar to #182, except that it keeps emacsGit building emacs
29.

Closes #185 