### PR TITLE
stable nixpkgsRelease: 21.05 -> 21.11

### DIFF
--- a/hydra/default.nix
+++ b/hydra/default.nix
@@ -41,7 +41,7 @@ let
     };
 
     stable = mkJobset {
-      nixpkgsRelease = "nixos-21.05";
+      nixpkgsRelease = "nixos-21.11";
       nixFile = "emacsen.nix";
       descriptionNote = "emacs";
     };


### PR DESCRIPTION
NixOS stable was bumped to 21.11 a few days ago and right now there are no cached builds for it, this change should fix that.