### PR TITLE
emacsPgtk: Use the master branch for pgtk build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -97,9 +97,9 @@ let
     }
   );
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-feature_pgtk.json { withSQLite3 = true; };
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
-  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-feature_pgtk.json { nativeComp = true; withSQLite3 = true; };
+  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { }).overrideAttrs (
     old: {

--- a/repos/emacs/emacs-feature_pgtk.json
+++ b/repos/emacs/emacs-feature_pgtk.json
@@ -1,1 +1,0 @@
-{"type": "savannah", "repo": "emacs", "rev": "7ab1b71c0dd878daa6806ce3a01d429dc5af646c", "sha256": "17lf869c3sqvk2c0pzkxizm1whfj9pm3rpd91vkr3m94kw4nf1ps", "version": "20211218.0"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -53,7 +53,6 @@ function update_release() {
 }
 
 update_savannah_branch master
-update_savannah_branch feature/pgtk
 update_release
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
Pgtk feature has been merged to master and the feature/pgtk branch will stop being used (the configure script will fail unconditionally since [8627f735425c8bc97f57a1b7915e36221873862f](https://git.savannah.gnu.org/cgit/emacs.git/commit/?h=feature/pgtk&id=8627f735425c8bc97f57a1b7915e36221873862f)). It should be safe to merge the pull request after the next ci update.