### PR TITLE
Use --without-ns for `nox` variants.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -107,6 +107,7 @@ in
   emacsGit-nox = (
     (
       emacsGit.override {
+        withNS = false;
         withX = false;
         withGTK2 = false;
         withGTK3 = false;
@@ -121,6 +122,7 @@ in
   emacsUnstable-nox = (
     (
       emacsUnstable.override {
+        withNS = false;
         withX = false;
         withGTK2 = false;
         withGTK3 = false;


### PR DESCRIPTION
Fixes installation of gui on darwin when nox is specified.
Closes #186 

Builds on x86_64-linux.