### PR TITLE
dropped alias: emacsPackagesGen -> emacsPackagesFor

### DIFF
--- a/elisp.nix
+++ b/elisp.nix
@@ -51,7 +51,7 @@ let
     inherit configText isOrgModeFile alwaysTangle;
     alwaysEnsure = doEnsure;
   };
-  emacsPackages = pkgs.emacsPackagesGen package;
+  emacsPackages = pkgs.emacsPackagesFor package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
   mkPackageError = name:
     let

--- a/packreq.nix
+++ b/packreq.nix
@@ -14,7 +14,7 @@ in
 }:
 let
   packages = parse.parsePackagesFromPackageRequires packageElisp;
-  emacsPackages = pkgs.emacsPackagesGen package;
+  emacsPackages = pkgs.emacsPackagesFor package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 in
 emacsWithPackages (epkgs:


### PR DESCRIPTION
Fixes the dropped alias in PR https://github.com/NixOS/nixpkgs/pull/161146.