### PR TITLE
'emacsPackagesGen' has been renamed to/replaced by 'emacsPackagesFor'

### DIFF
--- a/elisp.nix
+++ b/elisp.nix
@@ -51,7 +51,7 @@ let
     inherit configText isOrgModeFile alwaysTangle;
     alwaysEnsure = doEnsure;
   };
-  emacsPackages = pkgs.emacsPackagesGen package;
+  emacsPackages = pkgs.emacsPackagesFor package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
   mkPackageError = name:
     let

--- a/packreq.nix
+++ b/packreq.nix
@@ -14,7 +14,7 @@ in
 }:
 let
   packages = parse.parsePackagesFromPackageRequires packageElisp;
-  emacsPackages = pkgs.emacsPackagesGen package;
+  emacsPackages = pkgs.emacsPackagesFor package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 in
 emacsWithPackages (epkgs:


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/commit/a36f455905d55838a0d284656e096fbdb857cf3a removes aliases older the 2019-06-01, `emacsPackagesGen` was part of them.