### PR TITLE
rename emacsPackagesNgGen to emacsPackagesFor

### DIFF
--- a/repos/elpa/test.nix
+++ b/repos/elpa/test.nix
@@ -6,4 +6,4 @@ let
     ];
   };
 
-in pkgs.emacsPackagesNg
+in pkgs.emacsPackages

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -2,7 +2,7 @@
 
 let
   mkTestBuild = package: let
-    emacsPackages = pkgs.emacsPackagesNgGen package;
+    emacsPackages = pkgs.emacsPackagesFor package;
     emacsWithPackages = emacsPackages.emacsWithPackages;
   in emacsWithPackages(epkgs: [ ]);
 

--- a/repos/exwm/test.nix
+++ b/repos/exwm/test.nix
@@ -2,7 +2,7 @@
 
 let
   package = pkgs.emacs;
-  emacsPackages = pkgs.emacsPackagesNgGen package;
+  emacsPackages = pkgs.emacsPackagesFor package;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 in emacsWithPackages(epkgs: [
   epkgs.exwm

--- a/repos/melpa/test.nix
+++ b/repos/melpa/test.nix
@@ -7,5 +7,5 @@ let
   };
 
 in {
-  inherit (pkgs.emacsPackagesNg) melpaStablePackages melpaPackages;
+  inherit (pkgs.emacsPackages) melpaStablePackages melpaPackages;
 }


### PR DESCRIPTION
solves error `error: 'emacsPackagesNgGen' has been renamed to/replaced by 'emacsPackagesFor'`

should also solve #211 because the CI silently fails while updating the emacs and exwm repos
(see https://github.com/nix-community/emacs-overlay/runs/5504879838?check_suite_focus=true#step:6:2460 and https://github.com/nix-community/emacs-overlay/runs/5504879838?check_suite_focus=true#step:6:2622)


additionally renames old alias `emacsPackagesNg` to `emacsPackages`

- [x] tested emacs and exwm update scripts on my machine and verified the fix 