### PR TITLE
Add and use emacs-28 release channel

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -82,11 +82,11 @@ let
 
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
-  emacsGcc = (mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
+  emacsGcc = (mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-28.json { nativeComp = true; });
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-28.json { withSQLite3 = true; };
 
-  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
+  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-28.json { nativeComp = true; withSQLite3 = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 

--- a/repos/emacs/emacs-28.json
+++ b/repos/emacs/emacs-28.json
@@ -1,0 +1,1 @@
+{"type": "savannah", "repo": "emacs", "rev": "emacs-28.1", "sha256": "sha256-D33wnlxhx0LyG9WZaQDj2II3tG0HcJdZTC4dSA3lrgY=", "version": "28.1"}


### PR DESCRIPTION
This merge requests adds the newly released 28.x series starting it at 28.1 and using it for gcc and pgtk packages. (28.x supports both)

This should avoid breakages by staying on tagged releases.