### PR TITLE
Use git ls-remote to fetch latest tag

### DIFF
--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -42,9 +42,7 @@ function update_github_repo() {
 function update_release() {
     echo emacs release
 
-    git clone --shallow-since="$(date --date='-9 month')" https://git.savannah.gnu.org/git/emacs.git emacs_git_repo
-    tag=$(git -C emacs_git_repo tag -l --sort=-v:refname 'emacs-*' | grep -v '\-rc' | head -n1)
-    rm -rf emacs_git_repo
+    tag=$(git ls-remote --tags --refs --sort=-v:refname https://git.savannah.gnu.org/git/emacs.git 'emacs-[1-9]*' | grep -Eo 'emacs-.*' | grep -v '\-rc' | head -n1)
 
     digest=$(nix-prefetch-url --unpack "https://git.savannah.gnu.org/cgit/emacs.git/snapshot/emacs-${tag}.tar.gz")
     version_number=$(echo $tag | cut -d '-' -f 2)


### PR DESCRIPTION
See #217 for motivation: With the current method, only tags which are reachable from `master` are fetched, because shallow commits are single branch by default. In particular, the `emacs-28.1` tag does not show up because the `emacs-28` branch has not been merged back to master.

Note that I use `emacs-[1-9]*` instead of `emacs-*` because there are old tags of the form `emacs-pretest-X.Y.Z` (for X <= 24) which mess up Git's tag sorting. Note that `git ls-remote --tags` uses globs, and therefore `[1-9]*` means "a digit followed by any number of characters", not "any number of digits".