### PR TITLE
Change the emacsGcc attribute to emacsNativeComp

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,7 +57,7 @@ Emacs from git is not guaranteed stable and may break your setup at any
 time, if it breaks you get to keep both pieces.
 
 Furthermore we provide emacs compiled with the native compilation backend enabled
-under the attribute =emacsGcc=.
+under the attribute =emacsNativeComp=.
 
 We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies.

--- a/default.nix
+++ b/default.nix
@@ -82,7 +82,7 @@ let
 
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
-  emacsGcc = (mkGitEmacs "emacs-gcc" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
+  emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
   emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
@@ -94,7 +94,8 @@ in
 {
   inherit emacsGit emacsUnstable;
 
-  inherit emacsGcc;
+  inherit emacsNativeComp;
+  emacsGcc = builtins.trace "emacsGcc has been renamed to emacsNativeComp, please update your expression." emacsNativeComp;
 
   inherit emacsPgtk emacsPgtkGcc;
 


### PR DESCRIPTION
In upstream nixpkgs PR https://github.com/NixOS/nixpkgs/pull/168076
native compilation support was introduced to the nixpkgs attribute.
This is a better naming more in line with upstream, so we should also
adopt it.

I have aliased emacsGcc to emacsNativeComp for backwards compatibility
with a trace notice informing users about the change.

Additionally we will now default to the upstream native comp derivation if it exists.