### PR TITLE
Add emacsGitNativeComp attribute (#222)

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,7 +57,7 @@ Emacs from git is not guaranteed stable and may break your setup at any
 time, if it breaks you get to keep both pieces.
 
 Furthermore we provide emacs compiled with the native compilation backend enabled
-under the attribute =emacsNativeComp=.
+under the attributes =emacsNativeComp= (built from the latest tag) and =emacsGitNativeComp= (built from the latest =master= branch).
 
 We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies.

--- a/README.org
+++ b/README.org
@@ -61,7 +61,7 @@ under the attributes =emacsNativeComp= (built from the latest tag) and =emacsGit
 
 We also provide two attributes named =emacsGit-nox= and =emacsUnstable-nox=
 if you wish to have Emacs built without X dependencies.
-=emacsPgtk= and =emacsPgtkGcc= use the experimental pgtk branch which support Wayland natively.
+=emacsPgtk= and =emacsPgtkNativeComp= use the experimental pgtk feature which supports Wayland natively.
 
 ** Extra library functionality
 This overlay comes with extra functions to generate an Emacs closure

--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@ let
 
   emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
-  emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
+  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 
@@ -102,7 +102,8 @@ in
   inherit emacsNativeComp emacsGitNativeComp;
   emacsGcc = builtins.trace "emacsGcc has been renamed to emacsNativeComp, please update your expression." emacsNativeComp;
 
-  inherit emacsPgtk emacsPgtkGcc;
+  inherit emacsPgtk emacsPgtkNativeComp;
+  emacsPgtkGcc = builtins.trace "emacsPgtkGcc has been renamed to emacsPgtkNativeComp, please update your expression." emacsPgtkNativeComp;
 
   emacsGit-nox = (
     (

--- a/default.nix
+++ b/default.nix
@@ -84,6 +84,11 @@ let
 
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
+  emacsGitNativeComp = mkGitEmacs "emacs-git-native-comp" ./repos/emacs/emacs-master.json {
+    withSQLite3 = true;
+    nativeComp = true;
+  };
+
   emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
   emacsPgtkGcc = mkPgtkEmacs "emacs-pgtkgcc" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
@@ -94,7 +99,7 @@ in
 {
   inherit emacsGit emacsUnstable;
 
-  inherit emacsNativeComp;
+  inherit emacsNativeComp emacsGitNativeComp;
   emacsGcc = builtins.trace "emacsGcc has been renamed to emacsNativeComp, please update your expression." emacsNativeComp;
 
   inherit emacsPgtk emacsPgtkGcc;

--- a/hydra/emacsen.nix
+++ b/hydra/emacsen.nix
@@ -12,5 +12,5 @@ in {
   inherit (pkgs) emacsGit emacsGit-nox;
   inherit (pkgs) emacsPgtk;
 } // lib.optionalAttrs (lib.hasAttr "libgccjit" pkgs) {
-  inherit (pkgs) emacsGcc emacsPgtkGcc;
+  inherit (pkgs) emacsNativeComp emacsGitNativeComp emacsPgtkGcc;
 }

--- a/hydra/emacsen.nix
+++ b/hydra/emacsen.nix
@@ -12,5 +12,5 @@ in {
   inherit (pkgs) emacsGit emacsGit-nox;
   inherit (pkgs) emacsPgtk;
 } // lib.optionalAttrs (lib.hasAttr "libgccjit" pkgs) {
-  inherit (pkgs) emacsNativeComp emacsGitNativeComp emacsPgtkGcc;
+  inherit (pkgs) emacsNativeComp emacsGitNativeComp emacsPgtkNativeComp;
 }

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -9,6 +9,7 @@ let
 in {
   emacsUnstable = mkTestBuild pkgs.emacsUnstable;
   emacsGit = mkTestBuild pkgs.emacsGit;
+  emacsGitNativeComp = mkTestBuild pkgs.emacsGitNativeComp;
   emacsPgtk = mkTestBuild pkgs.emacsPgtk;
   emacsPgtkGcc = mkTestBuild pkgs.emacsPgtkGcc;
 }

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -11,5 +11,5 @@ in {
   emacsGit = mkTestBuild pkgs.emacsGit;
   emacsGitNativeComp = mkTestBuild pkgs.emacsGitNativeComp;
   emacsPgtk = mkTestBuild pkgs.emacsPgtk;
-  emacsPgtkGcc = mkTestBuild pkgs.emacsPgtkGcc;
+  emacsPgtkNativeComp = mkTestBuild pkgs.emacsPgtkNativeComp;
 }


### PR DESCRIPTION
As described in #222, this adds an emacs build from master with native compilation enabled, but without using pure GTK.

Additionally, I took the liberty to rename emacsPgtkGcc to emacsPgtkNativeComp to stay consistent with attribute naming.