### PR TITLE
Use `super.emacs` instead of `self.emacs`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
     in
     builtins.foldl'
       (drv: fn: fn drv)
-      self.emacs
+      super.emacs
       [
 
         (drv: drv.override ({ srcRepo = true; } // args))


### PR DESCRIPTION
If I'm not mistaken, we should be using `super.emacs` instead of `self.emacs` here.  Using `self.emacs` causes infinite loops if I try to overlay `emacs` later on and refer to something out of `emacs-overlay` (i.e. I want to overlay `emacs` in nixpkgs to point to the pgtk build so that anything that refers to `pkgs.emacs` directly doesn't accidentally pull in some x build that breaks on wayland)

cc @adisbladis 