### PR TITLE
Use `withPgtk` option to fix failing `emacsPgtk` build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,19 +75,20 @@ let
         )
       ];
 
-  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
+  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { nativeComp = false; };
 
+  # TODO: The default value of nativeComp was changed from false to true in June 2022. Remove "nativeComp = true;" when 22.11 is stable.
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
   emacsGitNativeComp = mkGitEmacs "emacs-git-native-comp" ./repos/emacs/emacs-master.json {
     nativeComp = true;
   };
 
-  emacsPgtk = mkGitEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withPgtk = true; };
+  emacsPgtk = mkGitEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withPgtk = true; nativeComp = false; };
 
   emacsPgtkNativeComp = mkGitEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withPgtk = true; };
 
-  emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
+  emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { nativeComp = false; });
 
 in
 {

--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
       super.emacs
       [
 
-        (drv: drv.override ({ srcRepo = true; } // args))
+        (drv: drv.override ({ srcRepo = true; withSQLite3 = true; withWebP = true; } // args))
 
         (
           drv: drv.overrideAttrs (
@@ -82,19 +82,17 @@ let
     }
   );
 
-  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { withSQLite3 = true; withWebP = true; };
+  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
 
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
   emacsGitNativeComp = mkGitEmacs "emacs-git-native-comp" ./repos/emacs/emacs-master.json {
-    withSQLite3 = true;
-    withWebP = true;
     nativeComp = true;
   };
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { };
 
-  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
+  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 

--- a/default.nix
+++ b/default.nix
@@ -75,13 +75,6 @@ let
         )
       ];
 
-  mkPgtkEmacs = namePrefix: jsonFile: { ... }@args: (mkGitEmacs namePrefix jsonFile args).overrideAttrs (
-    old: {
-      configureFlags = (super.lib.remove "--with-xft" old.configureFlags)
-        ++ super.lib.singleton "--with-pgtk";
-    }
-  );
-
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
 
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
@@ -90,9 +83,9 @@ let
     nativeComp = true;
   };
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { };
+  emacsPgtk = mkGitEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withPgtk = true; };
 
-  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; };
+  emacsPgtkNativeComp = mkGitEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withPgtk = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 

--- a/repos/emacs/emacs-master.json
+++ b/repos/emacs/emacs-master.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "e13509468b7cc733c3511310d999554e6bcda708", "sha256": "1865y9p1b338782pxgsnwm299p0qsp2a3xspnqrfsb5h10dmd0ap", "version": "20220903.0"}
+{"type": "savannah", "repo": "emacs", "rev": "b648634982bb52be2b21e92d4aeb837621b5ec63", "sha256": "0bg20qjbjg6a50yakj2g74hqm95imhmj5svk20b0r6lrlhvhza48", "version": "20220905.0"}


### PR DESCRIPTION
This appears to fix the issue in https://github.com/nix-community/emacs-overlay/runs/8170666387?check_suite_focus=true#step:6:35752 when used in conjunction with https://github.com/NixOS/nixpkgs/pull/189929.