### PR TITLE
Revert "Use `withPgtk` option to fix failing `emacsPgtk` build"

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
       super.emacs
       [
 
-        (drv: drv.override ({ srcRepo = true; withSQLite3 = true; withWebP = true; } // args))
+        (drv: drv.override ({ srcRepo = true; } // args))
 
         (
           drv: drv.overrideAttrs (
@@ -75,20 +75,28 @@ let
         )
       ];
 
-  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { nativeComp = false; };
+  mkPgtkEmacs = namePrefix: jsonFile: { ... }@args: (mkGitEmacs namePrefix jsonFile args).overrideAttrs (
+    old: {
+      configureFlags = (super.lib.remove "--with-xft" old.configureFlags)
+        ++ super.lib.singleton "--with-pgtk";
+    }
+  );
 
-  # TODO: The default value of nativeComp was changed from false to true in June 2022. Remove "nativeComp = true;" when 22.11 is stable.
+  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { withSQLite3 = true; withWebP = true; };
+
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
   emacsGitNativeComp = mkGitEmacs "emacs-git-native-comp" ./repos/emacs/emacs-master.json {
+    withSQLite3 = true;
+    withWebP = true;
     nativeComp = true;
   };
 
-  emacsPgtk = mkGitEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withPgtk = true; nativeComp = false; };
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; };
 
-  emacsPgtkNativeComp = mkGitEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withPgtk = true; };
+  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; };
 
-  emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { nativeComp = false; });
+  emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 
 in
 {

--- a/repos/emacs/emacs-master.json
+++ b/repos/emacs/emacs-master.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "b648634982bb52be2b21e92d4aeb837621b5ec63", "sha256": "0bg20qjbjg6a50yakj2g74hqm95imhmj5svk20b0r6lrlhvhza48", "version": "20220905.0"}
+{"type": "savannah", "repo": "emacs", "rev": "e13509468b7cc733c3511310d999554e6bcda708", "sha256": "1865y9p1b338782pxgsnwm299p0qsp2a3xspnqrfsb5h10dmd0ap", "version": "20220903.0"}


### PR DESCRIPTION
Reverts nix-community/emacs-overlay#240

@adisbladis I was intending for that other PR to be merged into here only after the unstable and 22.05 channels updated to contain https://github.com/NixOS/nixpkgs/pull/189939. I think the safe thing to do for now is to revert this PR. Sorry, I should have been clearer about the prerequisites.