### PR TITLE
Use upstream `withPgtk` input attribute and remove `mkPgtkEmacs`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
       super.emacs
       [
 
-        (drv: drv.override ({ srcRepo = true; } // args))
+        (drv: drv.override ({ srcRepo = true; withSQLite3 = true; withWebP = true; } // args))
 
         (
           drv: drv.overrideAttrs (
@@ -82,19 +82,17 @@ let
     }
   );
 
-  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { withSQLite3 = true; withWebP = true; };
+  emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
 
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
 
   emacsGitNativeComp = mkGitEmacs "emacs-git-native-comp" ./repos/emacs/emacs-master.json {
-    withSQLite3 = true;
-    withWebP = true;
     nativeComp = true;
   };
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withSQLite3 = true; withGTK3 = true; };
+  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withGTK3 = true; };
 
-  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; withGTK3 = true; };
+  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true;  withGTK3 = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 

--- a/default.nix
+++ b/default.nix
@@ -75,13 +75,6 @@ let
         )
       ];
 
-  mkPgtkEmacs = namePrefix: jsonFile: { ... }@args: (mkGitEmacs namePrefix jsonFile args).overrideAttrs (
-    old: {
-      configureFlags = (super.lib.remove "--with-xft" old.configureFlags)
-        ++ super.lib.singleton "--with-pgtk";
-    }
-  );
-
   emacsGit = mkGitEmacs "emacs-git" ./repos/emacs/emacs-master.json { };
 
   emacsNativeComp = super.emacsNativeComp or (mkGitEmacs "emacs-native-comp" ./repos/emacs/emacs-unstable.json { nativeComp = true; });
@@ -90,9 +83,9 @@ let
     nativeComp = true;
   };
 
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withGTK3 = true; };
+  emacsPgtk = mkGitEmacs "emacs-pgtk" ./repos/emacs/emacs-master.json { withPgtk = true; };
 
-  emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true;  withGTK3 = true; };
+  emacsPgtkNativeComp = mkGitEmacs "emacs-pgtk-native-comp" ./repos/emacs/emacs-master.json { nativeComp = true; withPgtk = true; };
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ./repos/emacs/emacs-unstable.json { });
 


### PR DESCRIPTION
This should now be safe to merge since the stable channel has updated
to contain https://github.com/NixOS/nixpkgs/commit/01ec6cc8e9064f51f538428fdb7311bcc44927ea, and similar for the nixos-unstable channel. (BTW, you can verify that I got the number of Darwin rebuilds down to 0 in the end with a follow-up cherry-pick)

I tested by installing `emacsPgtk` on GNOME Wayland.

Some things I found that I think are OK but could use review:

1. With this commit, because of some of the changes I made in upstream
nixpkgs with some of the boolean logic involving `withPgtk` and
`withGTK3`, an installation of `emacsPgtk` running in X (as opposed to
Wayland) will now complain on about having trouble finding
`g_settings_schema_source_lookup`:

``` markdown
(emacs:5810): GLib-GIO-CRITICAL **: 22:20:33.963: g_settings_schema_source_lookup: assertion 'source != NULL' failed
```

I believe this is OK because AFAIK `emacsPgtk` isn't intended for X
anyway. If this actually is an issue, then let me know and I can
submit a PR in nixpkgs to revert.

2. When using `emacsPgtk` on Wayland with my patched Emacs overlay, I don't
notice any difference compared to the current upstream Emacs overlay;
in both cases I see warnings like

``` markdown
Unable to load sb_v_double_arrow from the cursor theme
```

in GNOME. Given that your current upstream overlay also produces an
Emacs installation with this issue (one that I don't think has been
resolved upstream; see
https://lists.gnu.org/archive/html/emacs-devel/2020-11/msg01187.html),
I think it is not something to concern ourselves with.