### PR TITLE
elisp.nix: add a param to include user config as a default init file

### DIFF
--- a/README.org
+++ b/README.org
@@ -91,6 +91,17 @@ required in a user's config via =use-package= or =leaf=.
         # config = ./emacs.org;
         config = ./emacs.el;
 
+        # Whether to include your config as a default init file.
+        # If being bool, the value of config is used.
+        # Its value can also be a derivation like this if you want to do some
+        # substitution:
+        #   defaultInitFile = pkgs.substituteAll {
+        #     name = "default.el";
+        #     src = ./emacs.el;
+        #     inherit (config.xdg) configHome dataHome;
+        #   };
+        defaultInitFile = true;
+
         # Package is optional, defaults to pkgs.emacs
         package = pkgs.emacsGit;
 


### PR DESCRIPTION
This is good for AOT native compilation of user config.

Besides being bool, the value of this new option can also be a derivation produced by pkgs.substituteAll, which avoids IFD comparing to directly setting that derivation to the config param.

cc @leungbk