### PR TITLE
Treat store path as path

### DIFF
--- a/elisp.nix
+++ b/elisp.nix
@@ -32,16 +32,20 @@ let
   '';
   doEnsure = if (alwaysEnsure == null) then builtins.trace ensureNotice false else alwaysEnsure;
 
+  configType = config:
+    if (lib.strings.isStorePath config) then "path"
+    else (builtins.typeOf config);
+
   isOrgModeFile =
     let
       ext = lib.last (builtins.split "\\." (builtins.toString config));
-      type = builtins.typeOf config;
+      type = configType config;
     in
       type == "path" && ext == "org";
 
   configText =
     let
-      type = builtins.typeOf config;
+      type = configType config;
     in
       if type == "string" then config
       else if type == "path" then builtins.readFile config


### PR DESCRIPTION
For some reasons, I need to separate my configs into three `.org` file.

But, I also wanted to use the convenience provided by emacs-overlay - scanning packages that should be installed.

---

This PR provides the ability of using org files in `/nix/store`. For example:

```nix
configFile = pkgs.concatText "emacs-all-config.org" [
  ./files/core.org
  ./files/profile-main.org
  ./files/profile-term.org
];
configFilePath = builtins.toString configFile;

emacsPackage = pkgs.emacsWithPackagesFromUsePackage {
  package = pkgs.emacs;
  config = configFilePath;
  alwaysTangle = true;
};
```

In the meanwhile, this PR doesn't break anything.