### PR TITLE
Add `feature/tree-sitter` derivation to emacs overlay

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -112,7 +112,7 @@ let
 
   emacsUnstable = (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json { });
 
-  emacsGitTreeSitter = mkGitEmacs "emacs-git-tree-sitter" ../repos/emacs/emacs-feature_tree-sitter.json {
+  emacsGitTreeSitter = super.lib.makeOverridable (mkGitEmacs "emacs-git-tree-sitter" ../repos/emacs/emacs-feature_tree-sitter.json) {
     withTreeSitter = true;
     withTreeSitterPlugins = (plugins: with plugins; [
       tree-sitter-python

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -76,11 +76,11 @@ let
             lib = drv: ''lib${libName drv}.so'';
             linkCmd = drv: "ln -s ${drv}/parser $out/lib/${lib drv}";
             linkerFlag = drv: "-l" + libName drv;
-            plugins = args.withTreeSitterPlugins super.pkgs.tree-sitter-grammars;
-            tree-sitter-grammars = super.runCommand "tree-sitter-grammars" {
-            } (super.lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
+            plugins = args.withTreeSitterPlugins self.pkgs.tree-sitter-grammars;
+            tree-sitter-grammars = super.runCommand "tree-sitter-grammars" {}
+              (super.lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
           in {
-            buildInputs = old.buildInputs ++ [ super.pkgs.tree-sitter tree-sitter-grammars ];
+            buildInputs = old.buildInputs ++ [ self.pkgs.tree-sitter tree-sitter-grammars ];
             # before building the `.el` files, we need to allow the `tree-sitter` libraries
             # bundled in emacs to be dynamically loaded.
             TREE_SITTER_LIBS = super.lib.concatStringsSep " " ([ "-ltree-sitter" ] ++ (map linkerFlag plugins)); 
@@ -105,7 +105,7 @@ let
     withWebP = true;
     nativeComp = true;
   };
-  
+
   emacsPgtk = mkPgtkEmacs "emacs-pgtk" ../repos/emacs/emacs-master.json { withSQLite3 = true; withGTK3 = true; };
 
   emacsPgtkNativeComp = mkPgtkEmacs "emacs-pgtk-native-comp" ../repos/emacs/emacs-master.json { nativeComp = true; withSQLite3 = true; withGTK3 = true; };
@@ -118,6 +118,7 @@ let
       tree-sitter-python
       tree-sitter-javascript
       tree-sitter-json
+      tree-sitter-tsx
     ]);
   };
 

--- a/repos/emacs/emacs-feature_tree-sitter.json
+++ b/repos/emacs/emacs-feature_tree-sitter.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "57e37e9128b4f6f9a2aae0bc25de6c208d58e5d0", "sha256": "1h6zicpj6bym4nclcgwvjbdisi1v5psvmpz1lik7ha85jdscpnd2", "version": "20221010.0"}
+{"type": "savannah", "repo": "emacs", "rev": "260e47e9a3c9b3baecef81e69c218989dc0cd7a4", "sha256": "1j5pbrp1bb5q6vn5ykdim8jvxj466gh1i6brl5baphr3a2cvvja8", "version": "20221017.0"}

--- a/repos/emacs/emacs-feature_tree-sitter.json
+++ b/repos/emacs/emacs-feature_tree-sitter.json
@@ -1,0 +1,1 @@
+{"type": "savannah", "repo": "emacs", "rev": "57e37e9128b4f6f9a2aae0bc25de6c208d58e5d0", "sha256": "1h6zicpj6bym4nclcgwvjbdisi1v5psvmpz1lik7ha85jdscpnd2", "version": "20221010.0"}

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -7,6 +7,7 @@ let
   in emacsWithPackages(epkgs: [ ]);
 
 in {
+  emacsGitTreeSitter = mkTestBuild pkgs.emacsGitTreeSitter;
   emacsUnstable = mkTestBuild pkgs.emacsUnstable;
   emacsGit = mkTestBuild pkgs.emacsGit;
   emacsGitNativeComp = mkTestBuild pkgs.emacsGitNativeComp;

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -52,5 +52,6 @@ function update_release() {
 
 update_savannah_branch master
 update_release
+update_savannah_branch feature/tree-sitter
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
Fixes #226 for Linux.

I don't have a Mac to get this to work and test it for Darwin. I _think_ it will be a matter of switching `.so` to the required extension.

Note, the dynamic libraries need to be set during the `buildPhase` otherwise the build fails. As more languages get added into emacs core, more `tree-sitter-grammars` need to be added.