### PR TITLE
flake.nix: fix the hack of getting overlayAttrs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
           overlays = [ self.overlays.default ];
         };
         inherit (pkgs) lib;
-        overlayAttrs = builtins.attrNames (import ./. pkgs pkgs);
+        overlayAttrs = builtins.attrNames (self.overlays.emacs pkgs pkgs);
 
       in
       {


### PR DESCRIPTION
Before this patch and since #237, `overlayAttrs` is a list of all attrs in `all-packages.nix`, which breaks the usage of the `package` attr of this overlay.

But it should be only the attrs added by this overlay. This patch fixes this.