### PR TITLE
overlays: use a better and clearer way to compose overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
           overlays = [ self.overlays.default ];
         };
         inherit (pkgs) lib;
-        overlayAttrs = builtins.attrNames (self.overlays.emacs pkgs pkgs);
+        overlayAttrs = builtins.attrNames (import ./. pkgs pkgs);
 
       in
       {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,10 +1,9 @@
 self: super:
 let
-  inherit (super.lib) foldl' flip extends;
   overlays = [
     # package overlay must be applied before emacs overlay
     (import ./package.nix)
     (import ./emacs.nix)
   ];
 in
-foldl' (flip extends) (_: super) overlays self
+super.lib.composeManyExtensions overlays self super


### PR DESCRIPTION
The old way of composing overlays addes an unnecessay overlay, which
breaks the packages attribute of the flake. To reduce the impact on
users, I make a workaround[1] for that, which has been merged. Now I
figure out the real fix, which is to change `(_: super)` to `(_: {})`.

Additionally, the old way is a bit confusing.

This patch fixes both issues by using a better and clearer way to
compose overlays.

Since the workaround is no longer needed after this patch, I revert
that in the next commit.

[1]: https://github.com/nix-community/emacs-overlay/pull/256

cc @leungbk