### PR TITLE
emacs: add emacsLsp

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -122,6 +122,8 @@ let
     ]);
   };
 
+  emacsLsp = (mkGitEmacs "emacs-lsp" ../repos/emacs/emacs-lsp.json { nativeComp = true; });
+
 in
 {
   inherit emacsGit emacsUnstable;
@@ -163,6 +165,8 @@ in
   );
 
   inherit emacsGitTreeSitter;
+
+  inherit emacsLsp;
 
   emacsWithPackagesFromUsePackage = import ../elisp.nix { pkgs = self; };
 

--- a/repos/emacs/emacs-lsp.json
+++ b/repos/emacs/emacs-lsp.json
@@ -1,0 +1,1 @@
+{"type": "github", "owner": "emacs-lsp", "repo": "emacs", "rev": "955ac73cb3d04f86b2d0514317d58b8d41ac1922", "sha256": "0zh3zjx2bjvzzjqfqcmk1bm6nz5wpb7v3wivy6pyybbgkqarp15r", "version": "20221109.0"}


### PR DESCRIPTION
Add support for https://github.com/emacs-lsp/emacs, an emacs with support for async JSONRPC based on latest stable making LSP way faster.