### PR TITLE
resolves Issue #258

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -79,7 +79,9 @@ let
             linkCmd = drv:
               if super.stdenv.isDarwin
               then ''cp ${drv}/parser $out/lib/${lib drv}
-                     /usr/bin/install_name_tool -id $out/lib/${lib drv} $out/lib/${lib drv}''
+                     /usr/bin/install_name_tool -id $out/lib/${lib drv} $out/lib/${lib drv}
+                     codesign -s - -f $out/lib/${lib drv}
+                ''
               else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
             linkerFlag = drv: "-l" + libName drv;
 

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -83,7 +83,6 @@ let
                 ''
               else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
             linkerFlag = drv: "-l" + libName drv;
-
             plugins = args.withTreeSitterPlugins self.pkgs.tree-sitter-grammars;
             tree-sitter-grammars = super.runCommand "tree-sitter-grammars" {}
               (super.lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
@@ -140,7 +139,6 @@ let
       tree-sitter-json
       tree-sitter-tsx
       tree-sitter-typescript
-      tree-sitter-clojure
     ]);
   };
 

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -80,7 +80,7 @@ let
               if super.stdenv.isDarwin
               then ''cp ${drv}/parser $out/lib/${lib drv}
                      /usr/bin/install_name_tool -id $out/lib/${lib drv} $out/lib/${lib drv}
-                     codesign -s - -f $out/lib/${lib drv}
+                     /usr/bin/codesign -s - -f $out/lib/${lib drv}
                 ''
               else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
             linkerFlag = drv: "-l" + libName drv;

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -92,8 +92,7 @@ let
             # before building the `.el` files, we need to allow the `tree-sitter` libraries
             # bundled in emacs to be dynamically loaded.
             TREE_SITTER_LIBS = super.lib.concatStringsSep " " ([ "-ltree-sitter" ] ++ (map linkerFlag plugins));
-            # Fixes tree sitter error: "Buffer has no parser"
-            # Configure emacs where libraries exist nix store.
+            # Add to directories that tree-sitter looks in for language definitions / shared object parsers
             postPatch = old.postPatch + ''
                  substituteInPlace src/treesit.c \
                  --replace "Vtreesit_extra_load_path = Qnil;" \

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -75,7 +75,6 @@ let
             libName = drv: super.lib.removeSuffix "-grammar" drv.pname;
             libSuffix = if super.stdenv.isDarwin then "dylib" else "so";
             lib = drv: ''lib${libName drv}.${libSuffix}'';
-            # /usr/bin/codesign --deep -s - -f $out/lib/${lib drv}
             linkCmd = drv:
               if super.stdenv.isDarwin
               then ''cp ${drv}/parser $out/lib/${lib drv}


### PR DESCRIPTION
resolves Issue #258


MacOS support for tree-sitter 

**Tests performed**

- PR has been tested on aarch64-darwin only. 
- Tests conducted using pkgs.emacsGitTreeSitter
- Tested twice with nativeComp enabled & disabled. 
- Verified build succeeds
- Verified emacs boots up 
- Verified M-x bash-ts-mode works
- Verified treesit-extra-load-path set correctly
- Verified (treesit-language-available-p 'bash) returns true 

**How to test it yourself**

```
nix shell --no-write-lock-file github:jasonjckn/emacs-overlay/issue-258\#emacsGitTreeSitter -c emacs --version
```


Special thanks to [c4710n](https://github.com/c4710n) for half the work here. 