### PR TITLE
add tree sitter languages to rpath

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -104,6 +104,7 @@ let
             # Add to list of directories dlopen/dynlib_open searches for tree sitter languages *.so/*.dylib.
             postFixup = old.postFixup + super.lib.optionalString self.stdenv.isDarwin ''
                 /usr/bin/install_name_tool -add_rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
+                /usr/bin/codesign -s - -f $out/bin/emacs
               '' + super.lib.optionalString self.stdenv.isLinux ''
                 ${self.pkgs.patchelf}/bin/patchelf --add-rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
               '';

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -83,7 +83,6 @@ let
                      /usr/bin/codesign -s - -f $out/lib/${lib drv}
                 ''
               else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
-            linkerFlag = drv: "-l" + libName drv;
             plugins = with self.pkgs.tree-sitter-grammars; [
               tree-sitter-bash
               tree-sitter-c
@@ -101,20 +100,13 @@ let
               (super.lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
           in {
             buildInputs = old.buildInputs ++ [ self.pkgs.tree-sitter tree-sitter-grammars ];
-            # before building the `.el` files, we need to allow the `tree-sitter` libraries
-            # bundled in emacs to be dynamically loaded.
-            TREE_SITTER_LIBS = super.lib.concatStringsSep " " ([ "-ltree-sitter" ] ++ (map linkerFlag plugins));
-            # Add to directories that tree-sitter looks in for language definitions / shared object parsers
-            # FIXME: This was added for macOS, but it shouldn't be necessary on any platform.
-            # https://git.savannah.gnu.org/cgit/emacs.git/tree/src/treesit.c?h=64044f545add60e045ff16a9891b06f429ac935f#n533
-            # appends a bunch of filenames that appear to be incorrectly skipped over
-            # in https://git.savannah.gnu.org/cgit/emacs.git/tree/src/treesit.c?h=64044f545add60e045ff16a9891b06f429ac935f#n567
-            # on macOS, but are handled properly in Linux.
-            postPatch = old.postPatch + super.lib.optionalString super.stdenv.isDarwin ''
-                 substituteInPlace src/treesit.c \
-                 --replace "Vtreesit_extra_load_path = Qnil;" \
-                           "Vtreesit_extra_load_path = list1 ( build_string ( \"${tree-sitter-grammars}/lib\" ) );"
-            '';
+            TREE_SITTER_LIBS = "-ltree-sitter";
+            # Add to list of directories dlopen/dynlib_open searches for tree sitter languages *.so/*.dylib.
+            postFixup = old.postFixup + super.lib.optionalString self.stdenv.isDarwin ''
+                /usr/bin/install_name_tool -add_rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
+              '' + super.lib.optionalString self.stdenv.isLinux ''
+                ${self.pkgs.patchelf}/bin/patchelf --add-rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
+              '';
           }
         )
       )));


### PR DESCRIPTION
Follow up to my last PR, this is probably the correct way for dlopen/dynlib_open to locate the tree sitter parser *.so/*.dylib files, I believe this ought to work for both aarch64-darwin, and other *nix platforms, but i'll need someone to test it on x86.

I just ended up deleting the part that links the executable to the grammar shared objects, that seemed redundant to my current understanding. The purpose of doing a dlopen/dynlib_open is to dynamically load the shared objects at runtime. 

**How to test this branch**
```
nix build --refresh --recreate-lock-file --no-write-lock-file github:jasonjckn/emacs-overlay/rpath\#emacsGit
./result/bin/emacs --version
```

**Testing done on aarch64-darwin**
- bash-ts-mode works

