### PR TITLE
Expose useful attributes to end-user for customization

### DIFF
--- a/overlays/build.nix
+++ b/overlays/build.nix
@@ -1,0 +1,173 @@
+self: super: let
+  inherit (self) emacs emacsPackagesFor;
+  inherit
+    (super)
+    pkgs
+    callPackage
+    stdenv
+    lib
+    ;
+
+  # reconnect pkgs to the built emacs
+  forwardPkgs = drv:
+    drv.overrideAttrs (old: {
+      passthru =
+        old.passthru
+        // {
+          pkgs = emacsPackagesFor drv;
+        };
+    });
+in {
+  emacs-overlay =
+    (super.emacs-overlay or {})
+    // rec {
+      # Override an existing Emacs derivation with features (defined
+      # below).
+      #
+      # Only overrides the Elisp packages provided by emacs-overlay. To
+      # override the source of Emacs use `mkEmacsFromRepo`.
+      mkEmacsWithFeatures = features:
+        builtins.foldl'
+        (drv: fn: fn drv)
+        emacs
+        (features ++ [forwardPkgs]);
+
+      # Override an Emacs derivation with a custom source defined in
+      # emacs-overlay (see repos/default.nix for defined repositories).
+      #
+      # Example mkEmacsFromRepo { name = "test"; repo = emacs-overlay.repos.emacs.master; }
+      mkEmacsFromRepo = {
+        name,
+        features ? [],
+        repository,
+      }: let
+        setSource = drv:
+          (drv.override {srcRepo = true;}).overrideAttrs (old: {
+            name = "${name}-${repository.manifest.version}";
+            inherit (repository.manifest) version;
+            inherit (repository) src;
+            postPatch =
+              old.postPatch
+              + ''
+                substituteInPlace lisp/loadup.el \
+                --replace '(emacs-repository-get-version)' '"${repository.manifest.rev}"' \
+                --replace '(emacs-repository-get-branch)' '"master"'
+              '';
+          });
+      in
+        builtins.foldl'
+        (drv: fn: fn drv)
+        emacs
+        ([setSource]
+          ++ features
+          ++ [forwardPkgs]);
+
+      # Enable nativ comp feature for Emacs.
+      enableNativeCompilation = drv:
+        drv.overrideAttrs (
+          old: {
+            patches = [];
+            postPatch =
+              # XXX: remove when https://github.com/NixOS/nixpkgs/pull/193621 is merged
+              lib.optionalString (old ? NATIVE_FULL_AOT)
+              (let
+                backendPath =
+                  lib.concatStringsSep " "
+                  (builtins.map (x: ''\"-B${x}\"'') [
+                    # Paths necessary so the JIT compiler finds its libraries:
+                    "${lib.getLib pkgs.libgccjit}/lib"
+                    "${lib.getLib pkgs.libgccjit}/lib/gcc"
+                    "${lib.getLib stdenv.cc.libc}/lib"
+
+                    # Executable paths necessary for compilation (ld, as):
+                    "${lib.getBin stdenv.cc.cc}/bin"
+                    "${lib.getBin stdenv.cc.bintools}/bin"
+                    "${lib.getBin stdenv.cc.bintools.bintools}/bin"
+                  ]);
+              in ''
+                substituteInPlace lisp/emacs-lisp/comp.el --replace \
+                    "(defcustom comp-libgccjit-reproducer nil" \
+                    "(setq native-comp-driver-options '(${backendPath}))
+                    (defcustom comp-libgccjit-reproducer nil"
+              '');
+          }
+        );
+
+      # Enable tree-sitter with grammars by modifying the r-path of the
+      # Emacs executable.
+      #
+      # Example: enableTreeSitterWith (p: p; [tree-sitter-c])
+      enableTreeSitterWith = pluginsFn: drv:
+        (enableTreeSitter drv).overrideAttrs (
+          old: let
+            plugins = let
+              result = pluginsFn pkgs.tree-sitter-grammars;
+            in
+              if builtins.typeOf result != "list"
+              then throw "expected pluginsFn to return a list of grammars, but got ${builtins.typeOf result}"
+              else result;
+            tree-sitter-grammar-bundle = bundleTreeSitterGrammars plugins;
+          in {
+            buildInputs = old.buildInputs ++ [tree-sitter-grammar-bundle];
+            # Add to list of directories dlopen/dynlib_open searches for tree sitter languages *.so/*.dylib.
+            postFixup =
+              old.postFixup
+              + lib.optionalString stdenv.isDarwin ''
+                /usr/bin/install_name_tool -add_rpath ${lib.makeLibraryPath [tree-sitter-grammar-bundle]} $out/bin/emacs
+                /usr/bin/codesign -s - -f $out/bin/emacs
+              ''
+              + lib.optionalString stdenv.isLinux ''
+                ${pkgs.patchelf}/bin/patchelf --add-rpath ${lib.makeLibraryPath [tree-sitter-grammar-bundle]} $out/bin/emacs
+              '';
+          }
+        );
+
+      # Enable tree-sitter support without language grammars.
+      #
+      # Tree-sitter grammars must be provided via
+      # `treesit-extra-load-path` inside Emacs. Has the advantage that
+      # changing the set of tree-sitter libraries does not trigger a
+      # rebuild of Emacs itself (compared to `enableTreeSitterWith`).
+      enableTreeSitter = drv:
+        drv.overrideAttrs (
+          old: {
+            buildInputs = old.buildInputs ++ [pkgs.tree-sitter];
+            TREE_SITTER_LIBS = "-ltree-sitter";
+          }
+        );
+
+      # Enable PGTK feature.
+      enablePgtk = drv:
+        drv.overrideAttrs (
+          old: rec {
+            configureFlags =
+              (lib.remove "--with-xft" old.configureFlags)
+              ++ lib.singleton "--with-pgtk";
+          }
+        );
+
+      # Creates a bundle of tree-sitter grammars which are readable by
+      # Emacs.
+      bundleTreeSitterGrammars = plugins: let
+        libName = drv: lib.removeSuffix "-grammar" drv.pname;
+        libSuffix =
+          if stdenv.isDarwin
+          then "dylib"
+          else "so";
+        libFileName = drv: ''lib${libName drv}.${libSuffix}'';
+        linkCmd = drv:
+          if stdenv.isDarwin
+          then ''
+            cp ${drv}/parser $out/lib/${lib drv}
+            # FIXME: Is this kosher?
+            /usr/bin/install_name_tool -id $out/lib/${libFileName drv} $out/lib/${libFileName drv}
+            /usr/bin/codesign -s - -f $out/lib/${libFileName drv}
+          ''
+          else ''ln -s ${drv}/parser $out/lib/${libFileName drv}'';
+      in
+        pkgs.runCommand
+        "tree-sitter-grammars"
+        {}
+        (lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
+    };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,7 +2,9 @@ self: super:
 let
   overlays = [
     # package overlay must be applied before emacs overlay
+    (import ./repos.nix)
     (import ./package.nix)
+    (import ./build.nix)
     (import ./emacs.nix)
   ];
 in

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -1,89 +1,22 @@
-self: super:
-let
-  mkGitEmacs = namePrefix: jsonFile: { ... }@args:
-    let
-      repoMeta = super.lib.importJSON jsonFile;
-      fetcher =
-        if repoMeta.type == "savannah" then
-          super.fetchFromSavannah
-        else if repoMeta.type == "github" then
-          super.fetchFromGitHub
-        else
-          throw "Unknown repository type ${repoMeta.type}!";
-    in
-    builtins.foldl'
-      (drv: fn: fn drv)
-      super.emacs
-      ([
+self: super: let
+  inherit
+    (super.emacs-overlay)
+    mkEmacsFromRepo
+    enableTreeSitterWith
+    enablePgtk
+    enableNativeCompilation
+    repos
+    ;
 
-        (drv: drv.override ({ srcRepo = true; } // builtins.removeAttrs args [ "noTreeSitter" ]))
-
-        (
-          drv: drv.overrideAttrs (
-            old: {
-              name = "${namePrefix}-${repoMeta.version}";
-              inherit (repoMeta) version;
-              src = fetcher (builtins.removeAttrs repoMeta [ "type" "version" ]);
-
-              patches = [ ];
-
-              postPatch = old.postPatch + ''
-                substituteInPlace lisp/loadup.el \
-                --replace '(emacs-repository-get-version)' '"${repoMeta.rev}"' \
-                --replace '(emacs-repository-get-branch)' '"master"'
-              '' +
-              # XXX: remove when https://github.com/NixOS/nixpkgs/pull/193621 is merged
-                (super.lib.optionalString (old ? NATIVE_FULL_AOT)
-                    (let backendPath = (super.lib.concatStringsSep " "
-                      (builtins.map (x: ''\"-B${x}\"'') [
-                        # Paths necessary so the JIT compiler finds its libraries:
-                        "${super.lib.getLib self.libgccjit}/lib"
-                        "${super.lib.getLib self.libgccjit}/lib/gcc"
-                        "${super.lib.getLib self.stdenv.cc.libc}/lib"
-
-                        # Executable paths necessary for compilation (ld, as):
-                        "${super.lib.getBin self.stdenv.cc.cc}/bin"
-                        "${super.lib.getBin self.stdenv.cc.bintools}/bin"
-                        "${super.lib.getBin self.stdenv.cc.bintools.bintools}/bin"
-                      ]));
-                     in ''
-                        substituteInPlace lisp/emacs-lisp/comp.el --replace \
-                            "(defcustom comp-libgccjit-reproducer nil" \
-                            "(setq native-comp-driver-options '(${backendPath}))
-(defcustom comp-libgccjit-reproducer nil"
-                    ''));
-            }
-          )
-        )
-
-        # reconnect pkgs to the built emacs
-        (
-          drv:
-          let
-            result = drv.overrideAttrs (old: {
-              passthru = old.passthru // {
-                pkgs = self.emacsPackagesFor result;
-              };
-            });
-          in
-          result
-        )
-      ]
-      ++ (super.lib.optional (! (args ? "noTreeSitter")) (
-        drv: drv.overrideAttrs (old:
-          let
-            libName = drv: super.lib.removeSuffix "-grammar" drv.pname;
-            libSuffix = if super.stdenv.isDarwin then "dylib" else "so";
-            lib = drv: ''lib${libName drv}.${libSuffix}'';
-            linkCmd = drv:
-              if super.stdenv.isDarwin
-              then ''cp ${drv}/parser $out/lib/${lib drv}
-                     # FIXME: Is this kosher?
-                     /usr/bin/install_name_tool -id $out/lib/${lib drv} $out/lib/${lib drv}
-                     /usr/bin/codesign -s - -f $out/lib/${lib drv}
-                ''
-              else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
-            plugins = with self.pkgs.tree-sitter-grammars; [
+  emacsGit =
+    (mkEmacsFromRepo {
+      name = "emacs-git";
+      repository = repos.emacs.master;
+      features = [
+        enableNativeCompilation
+        (enableTreeSitterWith
+          (p:
+            with p; [
               tree-sitter-bash
               tree-sitter-c
               tree-sitter-c-sharp
@@ -97,88 +30,91 @@ let
               tree-sitter-json
               tree-sitter-tsx
               tree-sitter-typescript
-            ];
-            tree-sitter-grammars = super.runCommand "tree-sitter-grammars" {}
-              (super.lib.concatStringsSep "\n" (["mkdir -p $out/lib"] ++ (map linkCmd plugins)));
-          in {
-            buildInputs = old.buildInputs ++ [ self.pkgs.tree-sitter tree-sitter-grammars ];
-            TREE_SITTER_LIBS = "-ltree-sitter";
-            # Add to list of directories dlopen/dynlib_open searches for tree sitter languages *.so/*.dylib.
-            postFixup = old.postFixup + super.lib.optionalString self.stdenv.isDarwin ''
-                /usr/bin/install_name_tool -add_rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
-                /usr/bin/codesign -s - -f $out/bin/emacs
-              '' + super.lib.optionalString self.stdenv.isLinux ''
-                ${self.pkgs.patchelf}/bin/patchelf --add-rpath ${super.lib.makeLibraryPath [ tree-sitter-grammars ]} $out/bin/emacs
-              '';
-          }
-        )
-      )));
+            ]))
+      ];
+    })
+    .override {
+      withSQLite3 = true;
+      withWebP = true;
+    };
 
+  emacsPgtk =
+    (mkEmacsFromRepo {
+      name = "emacs-pgtk";
+      repository = repos.emacs.master;
+      features = [
+        enableNativeCompilation
+        enablePgtk
+      ];
+    })
+    .override {
+      withSQLite3 = true;
+      withWebP = true;
+      withGTK3 = true;
+    };
 
-  mkPgtkEmacs = namePrefix: jsonFile: { ... }@args: (mkGitEmacs namePrefix jsonFile args).overrideAttrs (
-    old: {
-      configureFlags = (super.lib.remove "--with-xft" old.configureFlags)
-        ++ super.lib.singleton "--with-pgtk";
-    }
-  );
+  emacsUnstable = mkEmacsFromRepo {
+    name = "emacs-unstable";
+    repository = repos.emacs.unstable;
+    features = [
+      enableNativeCompilation
+    ];
+  };
 
-  emacsGit = mkGitEmacs "emacs-git" ../repos/emacs/emacs-master.json { withSQLite3 = true; withWebP = true; };
-
-  emacsPgtk = mkPgtkEmacs "emacs-pgtk" ../repos/emacs/emacs-master.json { withSQLite3 = true; withWebP = true; withGTK3 = true; };
-
-  emacsUnstable = (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json { noTreeSitter = true; });
-
-  emacsLsp = (mkGitEmacs "emacs-lsp" ../repos/emacs/emacs-lsp.json { noTreeSitter = true; });
-
+  emacsLsp = mkEmacsFromRepo {
+    name = "emacs-lsp";
+    repository = repos.emacs.lsp;
+    features = [
+      enableNativeCompilation
+    ];
+  };
 in
-{
-  inherit emacsGit emacsUnstable;
+  {
+    inherit emacsGit emacsUnstable emacsPgtk emacsLsp;
 
-  inherit emacsPgtk;
+    emacsGit-nox = (
+      (
+        emacsGit.override {
+          withNS = false;
+          withX = false;
+          withGTK2 = false;
+          withGTK3 = false;
+          withWebP = false;
+        }
+      )
+      .overrideAttrs (
+        oa: {
+          name = "${oa.name}-nox";
+        }
+      )
+    );
 
-  emacsGit-nox = (
-    (
-      emacsGit.override {
-        withNS = false;
-        withX = false;
-        withGTK2 = false;
-        withGTK3 = false;
-        withWebP = false;
-      }
-    ).overrideAttrs (
-      oa: {
-        name = "${oa.name}-nox";
-      }
-    )
-  );
+    emacsUnstable-nox = (
+      (
+        emacsUnstable.override {
+          withNS = false;
+          withX = false;
+          withGTK2 = false;
+          withGTK3 = false;
+          withWebP = false;
+        }
+      )
+      .overrideAttrs (
+        oa: {
+          name = "${oa.name}-nox";
+        }
+      )
+    );
 
-  emacsUnstable-nox = (
-    (
-      emacsUnstable.override {
-        withNS = false;
-        withX = false;
-        withGTK2 = false;
-        withGTK3 = false;
-        withWebP = false;
-      }
-    ).overrideAttrs (
-      oa: {
-        name = "${oa.name}-nox";
-      }
-    )
-  );
+    emacsWithPackagesFromUsePackage = import ../elisp.nix {pkgs = self;};
 
-  inherit emacsLsp;
-
-  emacsWithPackagesFromUsePackage = import ../elisp.nix { pkgs = self; };
-
-  emacsWithPackagesFromPackageRequires = import ../packreq.nix { pkgs = self; };
-
-} // super.lib.optionalAttrs (super.config.allowAliases or true) {
-  emacsGcc = builtins.trace "emacsGcc has been renamed to emacsGit, please update your expression." emacsGit;
-  emacsGitNativeComp = builtins.trace "emacsGitNativeComp has been renamed to emacsGit, please update your expression." emacsGit;
-  emacsGitTreeSitter = builtins.trace "emacsGitTreeSitter has been renamed to emacsGit, please update your expression." emacsGit;
-  emacsNativeComp = builtins.trace "emacsNativeComp has been renamed to emacsUnstable, please update your expression." emacsUnstable;
-  emacsPgtkGcc = builtins.trace "emacsPgtkGcc has been renamed to emacsPgtk, please update your expression." emacsPgtk;
-  emacsPgtkNativeComp = builtins.trace "emacsPgtkNativeComp has been renamed to emacsPgtk, please update your expression." emacsPgtk;
-}
+    emacsWithPackagesFromPackageRequires = import ../packreq.nix {pkgs = self;};
+  }
+  // super.lib.optionalAttrs (super.config.allowAliases or true) {
+    emacsGcc = builtins.trace "emacsGcc has been renamed to emacsGit, please update your expression." emacsGit;
+    emacsGitNativeComp = builtins.trace "emacsGitNativeComp has been renamed to emacsGit, please update your expression." emacsGit;
+    emacsGitTreeSitter = builtins.trace "emacsGitTreeSitter has been renamed to emacsGit, please update your expression." emacsGit;
+    emacsNativeComp = builtins.trace "emacsNativeComp has been renamed to emacsUnstable, please update your expression." emacsUnstable;
+    emacsPgtkGcc = builtins.trace "emacsPgtkGcc has been renamed to emacsPgtk, please update your expression." emacsPgtk;
+    emacsPgtkNativeComp = builtins.trace "emacsPgtkNativeComp has been renamed to emacsPgtk, please update your expression." emacsPgtk;
+  }

--- a/overlays/repos.nix
+++ b/overlays/repos.nix
@@ -1,0 +1,8 @@
+self: super: {
+  emacs-overlay =
+    (super.emacs-overlay or {})
+    // {
+      repos =
+        super.callPackage ../repos {};
+    };
+}

--- a/repos/default.nix
+++ b/repos/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchFromSavannah,
+}: let
+  fetchFromJson = jsonFile: let
+    repoMeta = lib.importJSON jsonFile;
+  in {
+    src = (
+      if repoMeta.type == "savannah"
+      then fetchFromSavannah
+      else if repoMeta.type == "github"
+      then fetchFromGitHub
+      else throw "Unknown repository type ${repoMeta.type}!"
+    ) (builtins.removeAttrs repoMeta ["type" "version"]);
+    manifest = repoMeta;
+  };
+in {
+  emacs = {
+    lsp = fetchFromJson ./emacs/emacs-lsp.json;
+    master = fetchFromJson ./emacs/emacs-master.json;
+    unstable = fetchFromJson ./emacs/emacs-unstable.json;
+  };
+}


### PR DESCRIPTION
## Motivation

Currently it is not possible to turn off certain "features" provided by emacs-overlay (e.g. tree-sitter).


## Solution

Expose functions to the end-user which allows composing different features. These functions are exposed in `pkgs.emacs-overlays`. The attribute contains the features defined in `build.nix`. `pkgs.emacs-overlay` also contains the different Emacs repositories in `repo.emacs` which are defined in `repos/default.nix`. This way it is possible to create Emacs derivations with different features using different Emacs repositories.