### PR TITLE
Remove special casing for nongnuPackages

### DIFF
--- a/overlays/package.nix
+++ b/overlays/package.nix
@@ -42,17 +42,17 @@ in
             generated = ../repos/elpa/elpa-generated.nix;
           };
 
-          epkgs = esuper.override {
-            inherit melpaStablePackages melpaPackages elpaPackages;
-          };
-
-        in
-        epkgs
-        // super.lib.optionalAttrs (super.lib.hasAttr "nongnuPackages" esuper) {
           nongnuPackages = esuper.nongnuPackages.override {
             generated = ../repos/nongnu/nongnu-generated.nix;
           };
-        } // {
+
+          epkgs = esuper.override {
+            inherit melpaStablePackages melpaPackages elpaPackages
+              nongnuPackages;
+          };
+
+        in
+        epkgs // {
           xelb = mkExDrv eself "xelb" {
             packageRequires = [ eself.cl-generic eself.emacs ];
           };


### PR DESCRIPTION
With the current implementation, changes to the nongnuPackages attr of the emacs package set don't propagate to the set's top level. By removing the special-casing for non-gnu, and adding it to the epkgs override like the other package sources, this fixes the issue.
 
Fixes #292 .