### PR TITLE
flake: Add `emacsPackagesFor`, `emacsWithPackages*` to `lib` output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,11 @@
 
       in
       {
+        lib =
+          let
+            nonDrvAttrs = builtins.filter (n: !lib.isDerivation pkgs.${n}) overlayAttrs;
+          in
+          lib.listToAttrs (map (n: lib.nameValuePair n pkgs.${n}) nonDrvAttrs);
         packages =
           let
             drvAttrs = builtins.filter (n: lib.isDerivation pkgs.${n}) overlayAttrs;


### PR DESCRIPTION
`emacsPackagesFor`, `emacsWithPackagesFromPackageRequires`, `emacsWithPackagesFromUsePackage` were omitted from the `packages` output because they aren’t derivations. Expose them via a new `lib` output to enable using them without the overlay.