### PR TITLE
Codesign with pkgs.darwin.sigtool

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -86,7 +86,7 @@ let
                      chmod +w ./parser
                      install_name_tool -id $out/lib/${lib drv} ./parser
                      cp ./parser $out/lib/${lib drv}
-                     /usr/bin/codesign -s - -f $out/lib/${lib drv}
+                     ${self.pkgs.darwin.sigtool}/bin/codesign -s - -f $out/lib/${lib drv}
                 ''
               else ''ln -s ${drv}/parser $out/lib/${lib drv}'';
             plugins = args.treeSitterPlugins;


### PR DESCRIPTION
This replaces the `/usr/bin/codesign` reference with a nix-managed version of codesign.  That call [can fail](https://garnix.io/build/8B5mjYXB) with an "Operation not permitted" error when building `tree-sitter-grammars`:

```
tree-sitter-grammars> /private/tmp/nix-build-tree-sitter-grammars.drv-0/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 6: /usr/bin/codesign: Operation not permitted
              last 1 log lines:
              > /private/tmp/nix-build-tree-sitter-grammars.drv-0/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 6: /usr/bin/codesign: Operation not permitted
              For full logs, run 'nix log /nix/store/mdw5261xyb5zjncgvc9iav15jd4wsl7i-tree-sitter-grammars.drv'.
```