### PR TITLE
add tree-sitter-html

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -115,6 +115,7 @@ let
     tree-sitter-dockerfile
     tree-sitter-go
     tree-sitter-gomod
+    tree-sitter-html
     tree-sitter-java
     tree-sitter-javascript
     tree-sitter-json


### PR DESCRIPTION
html-ts-mode is built-in in GNU Emacs. Thus, add html grammar.