### PR TITLE
hydra: keep one evaluation only

### DIFF
--- a/hydra/default.nix
+++ b/hydra/default.nix
@@ -16,7 +16,7 @@ let
     schedulingshares = 100;
     enableemail = false;
     emailoverride = "";
-    keepnr = 3;
+    keepnr = 1;
     type = 0;  # Non-flake (legacy)
     inputs = {
       src = {

--- a/hydra/spec.json
+++ b/hydra/spec.json
@@ -8,7 +8,7 @@
   "schedulingshares": 100,
   "enableemail": false,
   "emailoverride": "",
-  "keepnr": 3,
+  "keepnr": 1,
   "type": 0,
   "inputs": {
     "src": {


### PR DESCRIPTION
builds are pushed to cachix so keeping multiple evaluations is unnecessary.

cc @Mic92 