### PR TITLE
flake: add nixConfig for build cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Bleeding edge Emacs overlay";
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-community.cachix.org" ];
+    extra-trusted-public-keys = [ "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
Enables the nix CLI to prompt the user to enable the flake's cache. (`nix run`, `nix profile install` etc)

Currently, the settings are stored to the user's nix.conf, so they're not scoped to the current run, but that may change down the road.  

The nixConfig is ignored when the flake is listed as an input to another flake (but again, tooling could solve this, eg by generating flake.nix.

I don't seem to be getting cache hits with the flake though, but that is orthogonal.