### PR TITLE
Use overrideScope' for override

### DIFF
--- a/README.org
+++ b/README.org
@@ -126,8 +126,8 @@ required in a user's config via =use-package= or =leaf=.
         ];
 
         # Optionally override derivations.
-        override = epkgs: epkgs // {
-          weechat = epkgs.melpaPackages.weechat.overrideAttrs(old: {
+        override = final: prev: {
+          weechat = prev.melpaPackages.weechat.overrideAttrs(old: {
             patches = [ ./weechat-el.patch ];
           });
         };

--- a/elisp.nix
+++ b/elisp.nix
@@ -20,7 +20,7 @@ in
 , alwaysTangle ? false
 , extraEmacsPackages ? epkgs: [ ]
 , package ? pkgs.emacs
-, override ? (epkgs: epkgs)
+, override ? (self: super: { })
 }:
 let
   ensureNotice = ''
@@ -53,7 +53,12 @@ let
     inherit configText isOrgModeFile alwaysTangle;
     alwaysEnsure = doEnsure;
   };
-  emacsPackages = pkgs.emacsPackagesFor package;
+  emacsPackages = (pkgs.emacsPackagesFor package).overrideScope' (self: super:
+    # for backward compatibility: override was a function with one parameter
+    if builtins.isFunction (override super)
+    then override self super
+    else override super
+  );
   emacsWithPackages = emacsPackages.emacsWithPackages;
   mkPackageError = name:
     let
@@ -63,9 +68,8 @@ let
 in
 emacsWithPackages (epkgs:
   let
-    overridden = override epkgs;
-    usePkgs = map (name: overridden.${name} or (mkPackageError name)) packages;
-    extraPkgs = extraEmacsPackages overridden;
+    usePkgs = map (name: epkgs.${name} or (mkPackageError name)) packages;
+    extraPkgs = extraEmacsPackages epkgs;
     defaultInitFilePkg =
       if !((builtins.isBool defaultInitFile) || (lib.isDerivation defaultInitFile))
       then throw "defaultInitFile must be bool or derivation"


### PR DESCRIPTION
This fixes an issue that override cannot override packages which are the dependencies of usePkgs and not in usePkgs.

This also preserves backward compatibility of override.  The hash of the generated Emacs package from emacsWithPackagesFromUsePackage does not change after this patch is applied using the old style override.