### PR TITLE
hydra: Lock nixpkgs input ref in Hydra builds to match flake

### DIFF
--- a/hydra/spec.json
+++ b/hydra/spec.json
@@ -18,7 +18,7 @@
     },
     "nixpkgs": {
       "type": "git",
-      "value": "https://github.com/NixOS/nixpkgs.git nixos-unstable",
+      "value": "https://github.com/NixOS/nixpkgs.git 0f213d0",
       "emailresponsible": false
     }
   }


### PR DESCRIPTION
Flake references `nixpkgs:0f213d0` however Hydra spec references `nixos-unstable` which is a moving target, causing generated hashes for cachix artifacts to not match those for the flake.

Fixes #305