### PR TITLE
Add emacsUnstablePgtk

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -144,13 +144,15 @@ let
 
   emacsUnstable = super.lib.makeOverridable (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json) { withSQLite3 = true; withWebP = true; treeSitterPlugins = defaultTreeSitterPlugins; };
 
+  emacsUnstablePgtk = super.lib.makeOverridable (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json) { withSQLite3 = true; withWebP = true; withPgtk = true; treeSitterPlugins = defaultTreeSitterPlugins; };
+
   emacsLsp = (mkGitEmacs "emacs-lsp" ../repos/emacs/emacs-lsp.json { noTreeSitter = true; });
 
 in
 {
   inherit emacsGit emacsUnstable;
 
-  inherit emacsPgtk;
+  inherit emacsPgtk emacsUnstablePgtk;
 
   emacsGit-nox = (
     (


### PR DESCRIPTION
Now that emacsUnstable is Emacs 29.0.90, we can add the pgtk variant.