### PR TITLE
added missing 'pkgs.' at start of package name for example.

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,6 +77,7 @@ For example, =emacsWithPackagesFromUsePackage= adds packages which are
 required in a user's config via =use-package= or =leaf=.
 
 #+BEGIN_SRC nix
+  { pkgs, ... }:
   {
     environment.systemPackages = [
       (pkgs.emacsWithPackagesFromUsePackage {

--- a/README.org
+++ b/README.org
@@ -79,7 +79,7 @@ required in a user's config via =use-package= or =leaf=.
 #+BEGIN_SRC nix
   {
     environment.systemPackages = [
-      (emacsWithPackagesFromUsePackage {
+      (pkgs.emacsWithPackagesFromUsePackage {
         # Your Emacs config file. Org mode babel files are also
         # supported.
         # NB: Config files cannot contain unicode characters, since


### PR DESCRIPTION
Hi after, trying to use the example code. I noticed that it was missing either the 'pkgs.' at the start of the package name, or the 'with pkgs' before the list of package names. I added the 'pkgs.' to the package name as that is what was used in the other example. To try and make the examples more consistent and easier to use.