### PR TITLE
Add commercial-emacs attribute

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -126,6 +126,11 @@ let
                   maybeOverridden = if (super.lib.hasAttr "treeSitter" base || super.lib.hasAttr "withTreeSitter" base) then base.override { withTreeSitter = false; } else base;
               in maybeOverridden;
 
+  commercial-emacs = super.lib.makeOverridable (mkGitEmacs "commercial-emacs" ../repos/emacs/commercial-emacs-commercial-emacs.json) {
+    withTreeSitter = false;
+    nativeComp = false;
+  };
+
   emacs-git-nox = (
     (
       emacs-git.override {
@@ -167,6 +172,8 @@ in
   inherit emacs-git-nox emacs-unstable-nox;
 
   inherit emacs-lsp;
+
+  inherit commercial-emacs;
 
   emacsWithPackagesFromUsePackage = import ../elisp.nix { pkgs = self; };
 

--- a/repos/emacs/commercial-emacs-commercial-emacs.json
+++ b/repos/emacs/commercial-emacs-commercial-emacs.json
@@ -1,0 +1,1 @@
+{"type": "github", "owner": "commercial-emacs", "repo": "commercial-emacs", "rev": "50771bb6107e32048187ab93f224cd307c733a33", "sha256": "03r4aqiljqg5g07jlbjp5sld0vg122gpb5ah4mpq2hl239qgxc3b", "version": "20230627.0"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -53,5 +53,6 @@ function update_release() {
 update_savannah_branch master
 update_release
 update_github_repo emacs-lsp emacs json-rpc lsp
+update_github_repo commercial-emacs commercial-emacs master commercial-emacs
 
 nix-build --no-out-link --show-trace ./test.nix


### PR DESCRIPTION
Despite the name, this is still GPL-licensed. [commercial-emacs/commercial-emacs](https://github.com/commercial-emacs/commercial-emacs).

Unfortunately, I wasn't able to get the tree-sitter override to work, which is why that's disabled for now.