### PR TITLE
commercial-emacs: replace deprecated nativeComp attribute

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -128,7 +128,7 @@ let
 
   commercial-emacs = super.lib.makeOverridable (mkGitEmacs "commercial-emacs" ../repos/emacs/commercial-emacs-commercial-emacs.json) {
     withTreeSitter = false;
-    nativeComp = false;
+    withNativeCompilation = false;
   };
 
   emacs-git-nox = (


### PR DESCRIPTION
On nixos-unstable, I see several repetitions of the following warning when running `nix flake check` in my personal config:

```
trace: warning: nativeComp option is deprecated and will be removed; use withNativeCompilation instead
```

Edit: ~The `commercial-emacs` package defined here is the only result I found for occurrences of `nativeComp` in my flake or its inputs.~ I didn’t find any occurrences of `nativeComp` in my own repo.