### PR TITLE
make extraEmacsPackages available when building default init file

### DIFF
--- a/elisp.nix
+++ b/elisp.nix
@@ -85,7 +85,7 @@ emacsWithPackages (epkgs:
                 then defaultInitFile
                 else throw "name of defaultInitFile must be ${defaultInitFileName}";
             version = "0.1.0";
-            packageRequires = usePkgs;
+            packageRequires = usePkgs ++ extraPkgs;
           };
   in
   usePkgs ++ extraPkgs ++ [ defaultInitFilePkg ])


### PR DESCRIPTION
gets rid of compile-time "not found" warnings about extra packages while building the default init file derivation, hopefully does change much otherwise (since the extra packages _are_ in the load-path at runtime anyway).