### PR TITLE
allow using Org config as defaultInitFile

### DIFF
--- a/elisp.nix
+++ b/elisp.nix
@@ -79,7 +79,13 @@ emacsWithPackages (epkgs:
             pname = "default";
             src =
               if defaultInitFile == true
-              then pkgs.writeText defaultInitFileName configText
+              then
+                if isOrgModeFile then pkgs.runCommand defaultInitFileName {} ''
+                  cp ${config} config.org
+                  ${package}/bin/emacs -Q --batch config.org -f org-babel-tangle
+                  cp config.el $out
+                ''
+                else pkgs.writeText defaultInitFileName configText
               else
                 if defaultInitFile.name == defaultInitFileName
                 then defaultInitFile


### PR DESCRIPTION
This commit is using Emacs for converting Org to Elisp.

I tried adding convertion before parsing (so that `repos/fromElisp` always receives an Elisp file), but Emacs complained about the resulting configs