### PR TITLE
Revert "Temporarily disable "emacs" update"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: ["elpa", "melpa", "fromElisp", "nongnu"]
+        repo: ["elpa", "emacs", "melpa", "fromElisp", "nongnu"]
     if: github.repository_owner == 'nix-community'
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This reverts commit c0ef7074c168adcb5f4038d9848eaedaeb5a27bc because [NixOS/nixpkgs#276943 has been merged into nixos-unstable](https://nixpk.gs/pr-tracker.html?pr=276943).

cc: @leungbk 