### PR TITLE
Fix geiser hash

### DIFF
--- a/repos/melpa/recipes-archive-melpa.json
+++ b/repos/melpa/recipes-archive-melpa.json
@@ -46197,7 +46197,7 @@
     "project"
    ],
    "commit": "0e189dfb1e531c7b2609c5865659badec7cb6f28",
-   "sha256": "0ilzbm0ylsbdimg0s2m9nw9m7mp9cz772dnn7my6wh26x4ia5jnq"
+   "sha256": "1aiw8fxfna58g3zcjg4rwr6jfaifdgp9nmcgd55kfbhps9ih0qi0"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
Fixes https://github.com/nix-community/emacs-overlay/issues/384

The geiser package hash is incorrect, and this sets it to the correct value.

While this file is autogenerated, perhaps it had some networking issue when generating the file?

I tried re-running the update script locally to test, but it gets stuck on my machine and does not get to updating the file.