### PR TITLE
Fix cache miss due to bytecomp-revert

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -91,25 +91,33 @@ let
   emacs-git = let base = (super.lib.makeOverridable (mkGitEmacs "emacs-git" ../repos/emacs/emacs-master.json) { withSQLite3 = true; withWebP = true; });
                   # TODO: remove when we drop support for < 23.05, and instead move withTreeSitter to the above line with the other arguments
                   maybeOverridden = if (super.lib.hasAttr "treeSitter" base || super.lib.hasAttr "withTreeSitter" base) then base.override { withTreeSitter = true; } else base;
+                  emacs = emacs-git;
               in
                 maybeOverridden.overrideAttrs (
                   oa: {
                     patches = oa.patches ++ [
                       # XXX: #318
                       ./bytecomp-revert.patch
-                    ]; }
-                );
+                    ];
+                    passthru = oa.passthru // {
+                        pkgs = oa.passthru.pkgs.overrideScope (eself: esuper: { inherit emacs; });
+                    };
+                  });
 
   emacs-pgtk = let base = super.lib.makeOverridable (mkGitEmacs "emacs-pgtk" ../repos/emacs/emacs-master.json) { withSQLite3 = true; withWebP = true; withPgtk = true; };
                    # TODO: remove when we drop support for < 23.05, and instead move withTreeSitter to the above line with the other arguments
                    maybeOverridden = if (super.lib.hasAttr "treeSitter" base || super.lib.hasAttr "withTreeSitter" base) then base.override { withTreeSitter = true; } else base;
+                   emacs = emacs-pgtk;
                in maybeOverridden.overrideAttrs (
                  oa: {
                    patches = oa.patches ++ [
                      # XXX: #318
                      ./bytecomp-revert.patch
-                   ]; }
-               );
+                   ];
+                    passthru = oa.passthru // {
+                        pkgs = oa.passthru.pkgs.overrideScope (eself: esuper: { inherit emacs; });
+                    };
+                 });
 
   emacs-unstable = let base = super.lib.makeOverridable (mkGitEmacs "emacs-unstable" ../repos/emacs/emacs-unstable.json) { withSQLite3 = true; withWebP = true; };
                        # TODO: remove when we drop support for < 23.05, and instead move withTreeSitter to the above line with the other arguments


### PR DESCRIPTION
Previously, using the Emacsen where bytecomp-revert.patch is applied could cause a costly cache miss, because `(emacs-attr).pkgs.emacs` was not updated to be equal to `(emacs-attr)`; instead, it remained as the unpatched version. This commit fixes that.

This was an issue if, for instance, one tried to install from `(emacs-attr).pkgs.*` directly into a profile/system. An Emacs without the patch would be depended upon, but that's not built by CI it seems, as nix would try to build it from scratch. I tested this with `packages.x86_64-linux.emacs-pgtk` vs. `packages.x86_64-linux.emacs-pgtk.pkgs.emacs`, the latter lacked the patch prior to this commit, whereas the former got pulled from cache.