### PR TITLE
Revert "Correct SmartParens hash" (Fix Linux break Darwin)

### DIFF
--- a/repos/melpa/recipes-archive-melpa.json
+++ b/repos/melpa/recipes-archive-melpa.json
@@ -112105,7 +112105,7 @@
     "dash"
    ],
    "commit": "d3b616843167f04b8a9f53dd25e84818c9f6fbce",
-   "sha256": "0gadjaq39g8zsh3lvbx29nm2lgyzna2x435xyf7rb89ly4v22wa6"
+   "sha256": "04vv9swkn3l2lcdb4ncmc6vr3967mglfgiabn1978gyhv4xp9nwm"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
Reverts nix-community/emacs-overlay#397

From the discussion in https://github.com/nix-community/emacs-overlay/issues/391 it looks like only Darwin systems had the invalid hash, this PR reverts the hash change in order to correct Linux systems.

I'll leave it to the maintainers on which OS should be broken while a actual hash correction is figured out.