### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,7 +11,7 @@ To get up and running quickly, add the following lines to your =/etc/nixos/confi
 
   nixpkgs.overlays = [
     (import (builtins.fetchTarball {
-      url = https://github.com/nix-community/emacs-overlay/archive/master.tar.gz;
+      url = "https://github.com/nix-community/emacs-overlay/archive/master.tar.gz";
     }))
   ];
 
@@ -173,7 +173,7 @@ cause compilation time.
 {
   nixpkgs.overlays = [
     (import (builtins.fetchTarball {
-      url = https://github.com/nix-community/emacs-overlay/archive/master.tar.gz;
+      url = "https://github.com/nix-community/emacs-overlay/archive/master.tar.gz";
     }))
   ];
 }


### PR DESCRIPTION
URL literals are deprecated in favour of strings