### PR TITLE
flake: drop aarch64-linux cross and build native

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
       # Run Hercules CI for these systems.
       herculesCI.ciSystems = [ "x86_64-linux" ];
 
-    } // flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    } // flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ] (system:
     {
       hydraJobs =
         let
@@ -57,25 +57,6 @@
                 inherit (pkgs) emacs-git emacs-git-nox;
                 inherit (pkgs) emacs-pgtk;
               };
-
-              emacsen-cross =
-                let
-                  crossTargets = [ "aarch64-multiplatform" ];
-                in
-                lib.fold lib.recursiveUpdate { }
-                  (builtins.map
-                    (target:
-                      let
-                        targetPkgs = pkgs.pkgsCross.${target};
-                      in
-                      lib.mapAttrs' (name: job: lib.nameValuePair "${name}-${target}" job)
-                        ({
-                          inherit (targetPkgs) emacs-unstable emacs-unstable-nox;
-                          inherit (targetPkgs) emacs-unstable-pgtk;
-                          inherit (targetPkgs) emacs-git emacs-git-nox;
-                          inherit (targetPkgs) emacs-pgtk;
-                        }))
-                    crossTargets);
 
               packages = mkEmacsSet pkgs.emacs;
               packages-unstable = mkEmacsSet pkgs.emacs-unstable;


### PR DESCRIPTION
We have an aarch64-linux builder. https://github.com/nix-community/infra/blob/master/devdoc/hosts.md#build04