### PR TITLE
recipes-archive-melpa: fix incorrect source hash of geiser

### DIFF
--- a/repos/melpa/recipes-archive-melpa.json
+++ b/repos/melpa/recipes-archive-melpa.json
@@ -47608,7 +47608,7 @@
     "project"
    ],
    "commit": "32196db8f8ddab071565a5ae6d799ada4f8fbe6b",
-   "sha256": "1wy8dfydamfrawvpz3vj0vjx2nq9z6sjw7gzxiqkb26cdc8isbkw"
+   "sha256": "13r87v4aqrdsk62jwp0ywnl0ih51fvgskygg9r6pr9cxswddfaim"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
Encountered an error while building `emacs-geiser`.

```
error: hash mismatch in fixed-output derivation '/nix/store/wqgzvkivjc1pwvh7l44n2fc9d3xy1ls0-source.drv':
         specified: sha256-fC4dEWvMiDVx7P8dLrX5CVvR5QZyj383V9lV1bxryPM=
             got:   sha256-NSrXGtedpXxNTu/5qd92ocAIqOUeXC6FmbplrMg+KI8=
```

If others encounter this as well, it can be merged here to fix.