### PR TITLE
Disable webkit2gtk integration

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -16,7 +16,7 @@ let
       super.emacs
       ([
 
-        (drv: drv.override ({ srcRepo = true; } // args))
+        (drv: drv.override ({ srcRepo = true; withXwidgets = false; } // args))
 
         (
           drv: drv.overrideAttrs (


### PR DESCRIPTION
See upstream bug https://lists.gnu.org/archive/html/bug-gnu-emacs/2024-09/msg00695.html

I submitted https://github.com/NixOS/nixpkgs/pull/344631 to the `staging` branch of nixpkgs, but since it may take a while for that to make its way into the unstable branch, I figured we could make the change here and revert later since the `webkitgtk` rejection during the `configure` phase is preventing the Emacs and MELPA jobs here from finishing.

closes https://github.com/nix-community/emacs-overlay/issues/426