### PR TITLE
Adapt Emacs update script to chop off more extraneous info

### DIFF
--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -10,7 +10,7 @@ function update_savannah_branch() {
     echo emacs $branch
 
     # Get relevant data (commit id and timestamp) for the latest commit
-    commit_data=$(curl "https://git.savannah.gnu.org/cgit/emacs.git/atom/?h=$branch" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1)
+    commit_data=$(curl "https://git.savannah.gnu.org/cgit/emacs.git/atom/?h=$branch" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1 | sed 's/^urn:sha1://')
 
     # Extract commit sha and build a version number based on date: YYYYMMDD.0
     commit_sha=$(echo $commit_data | cut -d '/' -f 1)


### PR DESCRIPTION
For example, see https://github.com/nix-community/emacs-overlay/actions/runs/11165733178/job/31038160001#step:6:350