### PR TITLE
flake: bump nixpkgs-stable from 24.05 to 24.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
   };
 
   outputs =


### PR DESCRIPTION
The update of `flake.lock` is left to be done by CI to avoid merge conflicts.