### PR TITLE
nativeComp + darwin: Allow emacs to find the path for libSystem

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -63,6 +63,9 @@ let
                         "${super.lib.getBin self.stdenv.cc.cc}/bin"
                         "${super.lib.getBin self.stdenv.cc.bintools}/bin"
                         "${super.lib.getBin self.stdenv.cc.bintools.bintools}/bin"
+                      ] ++ super.lib.optionals (self.stdenv.hostPlatform.isDarwin && super ? apple-sdk) [
+                        # The linker needs to know where to find libSystem on Darwin.
+                        "${super.apple-sdk.sdkroot}/usr/lib"
                       ])));
                      in ''
                         substituteInPlace lisp/emacs-lisp/comp.el --replace-warn \


### PR DESCRIPTION
This mirrors https://github.com/NixOS/nixpkgs/pull/361752 and removes the warning emitted about a malfunctioning libgccjit on Darwin when building emacs from git.