### PR TITLE
README: clarify `extraEmacsPackages` usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,8 +122,11 @@ required in a user's config via =use-package= or =leaf=.
         alwaysTangle = true;
 
         # Optionally provide extra packages not in the configuration file.
+        # This can also include extra executables to be run by Emacs (linters,
+        # language servers, formatters, etc)
         extraEmacsPackages = epkgs: [
           epkgs.cask
+          pkgs.shellcheck
         ];
 
         # Optionally override derivations.


### PR DESCRIPTION
Inspired by [`mu4e`'s recipe](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/emacs/elisp-packages/manual-packages/mu4e/package.nix#L13)

Now here's a lil issue i'd love to resolve:
- if you `nix build|run` such a closure, `extraPackages` won't be available
- only when this closure is installed (with `nix profile install` or adding it to `environment.systemPackages`/`home.packages`), `extraPackages` can be propagated.\*

Is this behaviour fine as is or should I make `extraPackages` always available?

\*Just tried with `nixos-rebuild test`, somehow this doesn't work :thinking: