### PR TITLE
Revert "Disable webkit2gtk integration"

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -16,7 +16,7 @@ let
       super.emacs
       ([
 
-        (drv: drv.override ({ srcRepo = true; withXwidgets = false; } // args))
+        (drv: drv.override ({ srcRepo = true; } // args))
 
         (
           drv: drv.overrideAttrs (


### PR DESCRIPTION
This reverts commit ce4ed6b670743b22ae3816b24cd3e72818246aad.

The needed change has reached stable and unstable Nixpkgs channels. No need to duplicate it here now.