### PR TITLE
Reapply "Disable webkit2gtk integration"

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -16,7 +16,7 @@ let
       super.emacs
       ([
 
-        (drv: drv.override ({ srcRepo = true; } // args))
+        (drv: drv.override ({ srcRepo = true; withXwidgets = false; } // args))
 
         (
           drv: drv.overrideAttrs (


### PR DESCRIPTION
This reverts commit 8823d476190cdaebc8d6c8bcf664b0179935e20d.

Due to the way the default values of withFoo flags are specified and the way Emacs variants are overridden, default values of those flags in this overlay may be incorrect.

This commit is a workaround.  We should do a proper fix later.