### PR TITLE
Add emacs-igc and emacs-igc-pgtk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
                 inherit (pkgs) emacs-unstable-pgtk;
                 inherit (pkgs) emacs-git emacs-git-nox;
                 inherit (pkgs) emacs-pgtk;
+                inherit (pkgs) emacs-igc emacs-igc-pgtk;
               };
 
               packages = mkEmacsSet pkgs.emacs;

--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -146,6 +146,38 @@ let
                               };
                             });
 
+  emacs-igc = let base = (mkGitEmacs "emacs-igc" ../repos/emacs/emacs-feature_igc.json) { };
+                  emacs = emacs-igc;
+              in
+                base.overrideAttrs (
+                  oa: {
+                    buildInputs = oa.buildInputs ++ [ super.mps ];
+                    configureFlags = oa.configureFlags ++ [ "--with-mps=yes" ];
+                    patches = oa.patches ++ [
+                      # XXX: #318
+                      ./bytecomp-revert.patch
+                    ];
+                    passthru = oa.passthru // {
+                      pkgs = oa.passthru.pkgs.overrideScope (eself: esuper: { inherit emacs; });
+                    };
+                  });
+
+  emacs-igc-pgtk = let base = (mkGitEmacs "emacs-igc-pgtk" ../repos/emacs/emacs-feature_igc.json) { withPgtk = true; };
+                       emacs = emacs-igc-pgtk;
+                   in
+                     base.overrideAttrs (
+                       oa: {
+                         buildInputs = oa.buildInputs ++ [ super.mps ];
+                         configureFlags = oa.configureFlags ++ [ "--with-mps=yes" ];
+                         patches = oa.patches ++ [
+                           # XXX: #318
+                           ./bytecomp-revert.patch
+                         ];
+                         passthru = oa.passthru // {
+                           pkgs = oa.passthru.pkgs.overrideScope (eself: esuper: { inherit emacs; });
+                         };
+                       });
+
   emacs-lsp = (mkGitEmacs "emacs-lsp" ../repos/emacs/emacs-lsp.json) { withTreeSitter = false; };
 
   commercial-emacs = (mkGitEmacs "commercial-emacs" ../repos/emacs/commercial-emacs-commercial-emacs.json) {
@@ -194,6 +226,8 @@ in
   inherit emacs-lsp;
 
   inherit commercial-emacs;
+
+  inherit emacs-igc emacs-igc-pgtk;
 
   emacsWithPackagesFromUsePackage = import ../elisp.nix { pkgs = self; };
 

--- a/repos/emacs/emacs-feature_igc.json
+++ b/repos/emacs/emacs-feature_igc.json
@@ -1,0 +1,1 @@
+{"type": "savannah", "repo": "emacs", "rev": "7146d10b4625043d8e36dd91ff1574568158dc55", "sha256": "0pf3q756iwpg2dssdxanv8w84rid6yzqvysdaii3g1gb2ffr00dg", "version": "20250123.0"}

--- a/repos/emacs/test.nix
+++ b/repos/emacs/test.nix
@@ -10,4 +10,5 @@ in {
   emacsUnstable = mkTestBuild pkgs.emacsUnstable;
   emacsGit = mkTestBuild pkgs.emacsGit;
   emacsPgtk = mkTestBuild pkgs.emacsPgtk;
+  emacsIgc = mkTestBuild pkgs.emacs-igc;
 }

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -51,6 +51,7 @@ function update_release() {
 }
 
 update_savannah_branch master
+update_savannah_branch feature/igc
 update_release
 update_github_repo emacs-lsp emacs json-rpc lsp
 update_github_repo commercial-emacs commercial-emacs master commercial-emacs


### PR DESCRIPTION
This pull request adds Emacs builds with the incremental garbage collector being developed on Emacs "feature/igc" branch.

The source repos/emacs/emacs-igc.json is currently fetched using `update_github_repo` because savannah returns a "429 Too Many Requests" for me currently (no matter the VPN).
The "--with-mps=yes" flag can also take the values "debug" or "no" and one could possibly add a new derivation input for this (like I do [here](https://github.com/naveen-seth/emacs-igc-overlay/blob/08158e9156d08085f289c3acca92bec9f25fe63f/flake.nix)).
I left that out for now to better fit with the current pattern.