### PR TITLE
Switch to using mirror emacs-mirror/emacs on github

### DIFF
--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -10,15 +10,15 @@ function update_savannah_branch() {
     echo emacs $branch
 
     # Get relevant data (commit id and timestamp) for the latest commit
-    commit_data=$(curl "https://git.savannah.gnu.org/cgit/emacs.git/atom/?h=$branch" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1 | sed 's/^urn:sha1://')
+    commit_data=$(curl "https://github.com/emacs-mirror/emacs/commits/$branch.atom" | xmlstarlet sel -N atom="http://www.w3.org/2005/Atom" -t -m /atom:feed/atom:entry -v "concat(atom:id,'/',atom:updated)" -n | head -n 1 | sed 's/^tag:github.com,2008:Grit::Commit\///')
 
     # Extract commit sha and build a version number based on date: YYYYMMDD.0
     commit_sha=$(echo $commit_data | cut -d '/' -f 1)
     version_number=$(echo $commit_data | cut -d '/' -f 2 | cut -d 'T' -f 1 | sed 's/-//g').0
 
     output_branch=$(echo $branch | sed s/"\/"/"_"/)
-    digest=$(nix-prefetch-url --unpack "https://git.savannah.gnu.org/cgit/emacs.git/snapshot/emacs-${commit_sha}.tar.gz")
-    echo "{\"type\": \"savannah\", \"repo\": \"emacs\", \"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-$output_branch.json
+    digest=$(nix-prefetch-url --unpack "https://github.com/emacs-mirror/emacs/archive/${commit_sha}.tar.gz")
+    echo "{\"type\": \"github\", \"owner\": \"emacs-mirror\", \"repo\": \"emacs\", \"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-$output_branch.json
 }
 
 function update_github_repo() {
@@ -42,17 +42,16 @@ function update_github_repo() {
 function update_release() {
     echo emacs release
 
-    tag=$(git ls-remote --tags --refs --sort=-v:refname https://git.savannah.gnu.org/git/emacs.git 'emacs-[1-9]*' | grep -Eo 'emacs-.*' | grep -v '\-rc' | head -n1)
+    tag=$(git ls-remote --tags --refs --sort=-v:refname https://github.com/emacs-mirror/emacs.git 'emacs-[1-9]*' | grep -Eo 'emacs-.*' | grep -v '\-rc' | head -n1)
 
-    digest=$(nix-prefetch-url --unpack "https://git.savannah.gnu.org/cgit/emacs.git/snapshot/${tag}.tar.gz")
+    digest=$(nix-prefetch-url --unpack "https://github.com/emacs-mirror/emacs/archive/refs/tags/${tag}.tar.gz")
     version_number=$(echo $tag | cut -d '-' -f 2)
 
-    echo "{\"type\": \"savannah\", \"repo\": \"emacs\", \"rev\": \"${tag}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-unstable.json
+    echo "{\"type\": \"github\", \"owner\": \"emacs-mirror\", \"repo\": \"emacs\", \"rev\": \"${tag}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-unstable.json
 }
 
-# https://github.com/nix-community/emacs-overlay/issues/460
-# update_savannah_branch master
-# update_release
+update_savannah_branch master
+update_release
 update_github_repo emacs-lsp emacs json-rpc lsp
 update_github_repo commercial-emacs commercial-emacs master commercial-emacs
 


### PR DESCRIPTION
Maybe switch to github emacs mirror to fix issues like #460 

Not sure if this is a welcome PR if not please close it.

```shell
% ./update emacs                    
+++ dirname repos/emacs/update
++ cd repos/emacs
++ pwd -P
+ SCRIPTPATH=~/dev/github/djgoku/emacs-overlay/repos/emacs
+ cd ~/dev/github/djgoku/emacs-overlay/repos/emacs
+ update_savannah_branch master
+ branch=master
+ echo emacs master
emacs master
++ curl https://github.com/emacs-mirror/emacs/commits/master.atom
++ xmlstarlet sel -N atom=http://www.w3.org/2005/Atom -t -m /atom:feed/atom:entry -v 'concat(atom:id,'\''/'\'',atom:updated)' -n
++ head -n 1
++ sed 's/^tag:github.com,2008:Grit::Commit\///'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21351  100 21351    0     0  58934      0 --:--:-- --:--:-- --:--:-- 58980
+ commit_data=92c5c1b786968b6d80f5d27455a40443a3a8f0e8/2025-01-22T23:07:36Z
++ echo 92c5c1b786968b6d80f5d27455a40443a3a8f0e8/2025-01-22T23:07:36Z
++ cut -d / -f 1
+ commit_sha=92c5c1b786968b6d80f5d27455a40443a3a8f0e8
++ echo 92c5c1b786968b6d80f5d27455a40443a3a8f0e8/2025-01-22T23:07:36Z
++ cut -d / -f 2
++ cut -d T -f 1
++ sed s/-//g
+ version_number=20250122.0
++ echo master
++ sed 's/\//_/'
+ output_branch=master
++ nix-prefetch-url --unpack https://github.com/emacs-mirror/emacs/archive/92c5c1b786968b6d80f5d27455a40443a3a8f0e8.tar.gz
path is '/nix/store/5f2ql8ky8ghwyhqqclr9fzb1hmvw9ix5-92c5c1b786968b6d80f5d27455a40443a3a8f0e8.tar.gz'
+ digest=0ahia6jndl20sczzl40ndqs0bj6ddmczqsmq7cghsdh3j53mzign
+ echo '{"type": "github", "owner": "emacs-mirror", "repo": "emacs", "rev": "92c5c1b786968b6d80f5d27455a40443a3a8f0e8", "sha256": "0ahia6jndl20sczzl40ndqs0bj6ddmczqsmq7cghsdh3j53mzign", "version": "20250122.0"}'
[feat/maybe-use-github-emacs-mirror-of-emacs 1abbfcbdc] Updated emacs
 2 files changed, 8 insertions(+), 8 deletions(-)
```