### PR TITLE
repos/emacs: Rewrite unstable updater using Python

### DIFF
--- a/repos/emacs/emacs-unstable.json
+++ b/repos/emacs/emacs-unstable.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "emacs-30.1-rc1", "sha256": "172q4jsfhlccp5i9z7vsn9z1n8amdwb8ak1jqm7ybwpr5941whbr", "version": "30.1"}
+{"type": "savannah", "repo": "emacs", "rev": "emacs-30.1", "sha256": "02lcgfxv4ybbbisam3mdbcjaww3vim5h26502vxixh3kw4p9c6y0", "version": "30.1"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p curl xmlstarlet nix coreutils
+#! nix-shell -i bash -p curl xmlstarlet nix coreutils 'python3.withPackages(ps: [ ps.packaging ])'
 set -euxo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
@@ -41,13 +41,7 @@ function update_github_repo() {
 
 function update_unstable() {
     echo emacs unstable
-
-    tag=$(git ls-remote --tags --refs --sort=-v:refname https://git.savannah.gnu.org/git/emacs.git 'emacs-[1-9]*' | grep -Eo 'emacs-.*' | head -n1)
-
-    digest=$(nix-prefetch-url --unpack "https://git.savannah.gnu.org/cgit/emacs.git/snapshot/${tag}.tar.gz")
-    version_number=$(echo $tag | cut -d '-' -f 2)
-
-    echo "{\"type\": \"savannah\", \"repo\": \"emacs\", \"rev\": \"${tag}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-unstable.json
+    python3 ./update-unstable.py
 }
 
 update_savannah_branch master

--- a/repos/emacs/update-unstable.py
+++ b/repos/emacs/update-unstable.py
@@ -1,0 +1,72 @@
+from packaging.version import Version, InvalidVersion
+import subprocess
+import json
+
+# (Ab)use Python's PEP-440 version parsing for sorting Emacs versions.
+# Emacs versions aren't exactly PEP-440, but `git ls-remote`'s sort function does not support -rc
+# suffixes and neither does GNU sort.
+# Meaning that older -rc releases may be prefered to a later stable release.
+
+TAG_PREAMBLE = "refs/tags/emacs-"
+
+
+def main():
+    proc = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            "--refs",
+            "https://git.savannah.gnu.org/git/emacs.git",
+            "emacs-[1-9]*",
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+
+    tags: list[str] = []
+    for line in proc.stdout.decode().splitlines():
+        _commit, ref = line.split("\t")
+        if not ref.startswith(TAG_PREAMBLE):
+            continue
+
+        tag = ref[len(TAG_PREAMBLE) :]
+
+        # Skip unparseable versions
+        try:
+            Version(tag)
+        except InvalidVersion:
+            pass
+        else:
+            tags.append(tag)
+
+    latest_version = sorted(tags, key=lambda tag: Version(tag))[-1]
+    latest_tag = f"emacs-{latest_version}"
+
+    proc = subprocess.run(
+        [
+            "nix-prefetch-url",
+            "--unpack",
+            f"https://git.savannah.gnu.org/cgit/emacs.git/snapshot/{latest_tag}.tar.gz",
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    digest = proc.stdout.decode().strip()
+
+    with open("./emacs-unstable.json", "w") as fp:
+        json.dump(
+            {
+                "type": "savannah",
+                "repo": "emacs",
+                "rev": latest_tag,
+                "sha256": digest,
+                "version": latest_version,
+            },
+            fp,
+        )
+        fp.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
So that we can use https://packaging.pypa.io/en/latest/version.html to parse/sort version numbers correctly for `-rc` releases.

See https://github.com/nix-community/emacs-overlay/issues/470#issuecomment-2695930027.