### PR TITLE
.github: pin Nix 2.24.12 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.24.12/install
 
     - name: Add nix-community cache
       uses: cachix/cachix-action@v15
@@ -56,6 +57,7 @@ jobs:
       uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.24.12/install
 
     - name: Add nix-community cache
       uses: cachix/cachix-action@v15

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
       - id: set-matrix
         name: Evaluate flake
         run: nix flake show --all-systems


### PR DESCRIPTION
https://github.com/nix-community/emacs-overlay/issues/474

cachix/install-nix-action@v30 [by default](https://github.com/cachix/install-nix-action/blob/08dcb3a5e62fa31e2da3d490afc4176ef55ecd72/install-nix.sh#L96) installs nix-2.24.9, which has bug https://github.com/NixOS/nix/issues/11681.