### PR TITLE
feat: Set darwin cflags `fd_setsize` and `darwin_unlimited_select`

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -73,6 +73,9 @@ let
                             "(setq native-comp-driver-options '(${backendPath}))
 (defcustom comp-libgccjit-reproducer nil"
                     ''));
+              env = old.env or { } // {
+                NIX_CFLAGS_COMPILE = (old.env.NIX_CFLAGS_COMPILE or "") +  self.lib.optionalString self.stdenv.hostPlatform.isDarwin " -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT ";
+              };
             }
           )
         )


### PR DESCRIPTION
I’m not sure if you’re open to this change. If not, we can close this PR.

I’ve been having issues with macOS when I have too many files open. I’ve been testing this for a few weeks, and I haven’t encountered any more errors from Emacs about too many files open.

Prior work

https://github.com/d12frosted/homebrew-emacs-plus/commit/4b34ed7402a4f3e1f212b2c6fa0851f4b59e247c

Context

https://en.liujiacai.net/2022/09/03/emacs-maxopenfiles/