### PR TITLE
Revert ".github: pin Nix 2.24.12 for CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-        install_url: https://releases.nixos.org/nix/nix-2.24.12/install
 
     - name: Add nix-community cache
       uses: cachix/cachix-action@v16
@@ -57,7 +56,6 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-        install_url: https://releases.nixos.org/nix/nix-2.24.12/install
 
     - name: Add nix-community cache
       uses: cachix/cachix-action@v16

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-          install_url: https://releases.nixos.org/nix/nix-2.24.12/install
       - id: set-matrix
         name: Evaluate flake
         run: nix flake show --all-systems


### PR DESCRIPTION
Reverts nix-community/emacs-overlay#477

After #483 is merged, the default nix version in CI is 2.26.3 which has no issues mentioned in #474.  So #477 is not needed any more.