### PR TITLE
forge-llm: fix src hash

### DIFF
--- a/repos/melpa/recipes-archive-melpa.json
+++ b/repos/melpa/recipes-archive-melpa.json
@@ -46682,7 +46682,7 @@
     "llm"
    ],
    "commit": "62c925deffcddd30256d6827040fb9faf13119d3",
-   "sha256": "10ad27iw9hg6x2bq6ws44452mlmwln8mpy9ah5c0001plfsc8mxp"
+   "sha256": "003m9c05d29m17yzpyms4vf2kw9rjh393hkipjcyvxpdigxzb3nm"
   }
  },
  {


### PR DESCRIPTION
https://hydra.nix-community.org/build/4840731

Hopefully, this is the last hash fix with https://github.com/NixOS/nixpkgs/pull/397761 merged.