### PR TITLE
Remove emacs-pgtk to not shadow the one from Nixpkgs

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -224,5 +224,4 @@ in
   emacsGitNox = builtins.trace "emacsGitNox has been renamed to emacs-git-nox, please update your expression." emacs-git-nox;
   emacsUnstableNox = builtins.trace "emacsUnstableNox has been renamed to emacs-unstable-nox, please update your expression." emacs-unstable-nox;
   emacsLsp = builtins.trace "emacsLsp has been renamed to emacs-lsp, please update your expression." emacs-lsp;
-  emacs-pgtk = builtins.trace "emacs-pgtk has been renamed to emacs-git-pgtk. emacs-pgtk will be removed from this overlay.  After that, it will point to the one in Nixpkgs." emacs-git-pgtk;
 }


### PR DESCRIPTION
Users have been notified for about 4 months[1] which should be long enough.

This is the second and last PR for #471.  Fixes #471.

[1]: #473