### PR TITLE
Fetch Emacs source via git instead of cgit snapshot

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -5,7 +5,7 @@ let
       repoMeta = super.lib.importJSON jsonFile;
       fetcher =
         if repoMeta.type == "savannah" then
-          super.fetchFromSavannah
+          super.fetchgit
         else if repoMeta.type == "github" then
           super.fetchFromGitHub
         else

--- a/repos/emacs/emacs-feature_igc.json
+++ b/repos/emacs/emacs-feature_igc.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "e0517ecbe680e5d4a271d72fc578859069d431d6", "sha256": "0w94a13fnb6agljb2dfn3iyn6816s8vnakyai5s7y7ldvvl2b005", "version": "20251205.0"}
+{"type": "savannah", "url": "git://git.savannah.gnu.org/emacs.git", "rev": "03b258fe443ef1cbdeea516d8cf85077e5d6a3dc", "sha256": "1n2i9bv552fb3qhy8gi4ci29fgrdn6w9dc1aqi6ndxls4pbpp2n8", "version": "20251206.0"}

--- a/repos/emacs/emacs-master.json
+++ b/repos/emacs/emacs-master.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "da45a474d32de0a19f706e772afde3be2b8772f6", "sha256": "1pbszrzd74bzvyif7ysbrmd4vmghzqk2in16gz51yzqw22rsxmyq", "version": "20251206.0"}
+{"type": "savannah", "url": "git://git.savannah.gnu.org/emacs.git", "rev": "223dffabd8f601b70452998c1cf4c845c4ecbf15", "sha256": "01hn5c6mg641cvxxlqqz1iqrn2xqsf2vsks8d61wwcxbb9dsi9pg", "version": "20251213.0"}

--- a/repos/emacs/emacs-unstable.json
+++ b/repos/emacs/emacs-unstable.json
@@ -1,1 +1,1 @@
-{"type": "savannah", "repo": "emacs", "rev": "emacs-30.2", "sha256": "083m092ad4djy5r5g3jx3wchdbm5wzpcapq2ky97m5cxgbfdpdyw", "version": "30.2"}
+{"type": "savannah", "url": "git://git.savannah.gnu.org/emacs.git", "rev": "emacs-30.2", "sha256": "083m092ad4djy5r5g3jx3wchdbm5wzpcapq2ky97m5cxgbfdpdyw", "version": "30.2"}

--- a/repos/emacs/update
+++ b/repos/emacs/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p curl xmlstarlet nix coreutils 'python3.withPackages(ps: [ ps.packaging ])'
+#! nix-shell -i bash -p curl xmlstarlet nix coreutils 'python3.withPackages(ps: [ ps.packaging ])' nix-prefetch-git jq
 set -euxo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
@@ -17,8 +17,8 @@ function update_savannah_branch() {
     version_number=$(echo $commit_data | cut -d '/' -f 2 | cut -d 'T' -f 1 | sed 's/-//g').0
 
     output_branch=$(echo $branch | sed s/"\/"/"_"/)
-    digest=$(nix-prefetch-url --unpack "https://git.savannah.gnu.org/cgit/emacs.git/snapshot/emacs-${commit_sha}.tar.gz")
-    echo "{\"type\": \"savannah\", \"repo\": \"emacs\", \"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-$output_branch.json
+    digest=$(nix-prefetch-git --rev $commit_sha "git://git.savannah.gnu.org/emacs.git" | jq -r .sha256)
+    echo "{\"type\": \"savannah\", \"url\": \"git://git.savannah.gnu.org/emacs.git\", \"rev\": \"${commit_sha}\", \"sha256\": \"${digest}\", \"version\": \"${version_number}\"}" > emacs-$output_branch.json
 }
 
 function update_github_repo() {

--- a/repos/emacs/update-unstable.py
+++ b/repos/emacs/update-unstable.py
@@ -45,22 +45,23 @@ def main():
 
     proc = subprocess.run(
         [
-            "nix-prefetch-url",
-            "--unpack",
-            f"https://git.savannah.gnu.org/cgit/emacs.git/snapshot/{latest_tag}.tar.gz",
+            "nix-prefetch-git",
+            "--rev",
+            f"refs/tags/{latest_tag}",
+            "git://git.savannah.gnu.org/emacs.git",
         ],
         stdout=subprocess.PIPE,
         check=True,
     )
-    digest = proc.stdout.decode().strip()
+    digest = json.loads(proc.stdout.decode().strip())
 
     with open("./emacs-unstable.json", "w") as fp:
         json.dump(
             {
                 "type": "savannah",
-                "repo": "emacs",
+                "url": "git://git.savannah.gnu.org/emacs.git",
                 "rev": latest_tag,
-                "sha256": digest,
+                "sha256": digest['sha256'],
                 "version": latest_version,
             },
             fp,


### PR DESCRIPTION
Tested locally, this allows fetching and building of upstream emacs repos again.