### PR TITLE
Work around race condition of git between elpa and nongnu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,5 @@ jobs:
 
     - name: Push commit with updated inputs
       run: |
-        # work around race of git between elpa and nongnu
-        # Between elpa runs `git pull` and `git push`, nongnu may run `git
-        # push`.  Let elpa sleep for 20 seconds and hopefully nongnu has
-        # finished `git push`.
-        [[ ${{ matrix.repo }} == "elpa" ]] && sleep 20
         git pull --rebase --autostash
         git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         ./update ${{ matrix.repo }}
 
     - name: Push commit with updated inputs
-      run: |
-        git pull --rebase --autostash
-        git push
+      # if git fails due to race condition, we retry
+      run: >
+        git pull --rebase --autostash && git push
+        || git pull --rebase --autostash && git push


### PR DESCRIPTION
This reverts #527 and uses another approach (retry).

Example of the race condition: https://github.com/nix-community/emacs-overlay/actions/runs/26031284373/job/76517840520