### PR TITLE
ci: allow update job of emacs to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         repo: ["elpa", "emacs", "melpa", "fromElisp", "nongnu"]
     if: github.repository_owner == 'nix-community'
+    continue-on-error: ${{ matrix.repo == 'emacs' }} # update of emacs can be flaky
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Update of Emacs is kind of flaky, recently.

Previously, if update job of Emacs failed, remaining update jobs, usually just the update for MELPA, for elisp pkgs were also canceled. This is bad because we only got some pkg set updated.  With this patch, update jobs for elisp pkgs continue to run even if update job of Emacs fails.

For `git clone`, the git protocol[1] is more reliable than the HTTPS protocol[2].  However, the git protocol is not secure.  Whether we should switch to the git protocol from the HTTPS protocol is unclear.

Fixes: #535

[1]: git://git.git.savannah.gnu.org/emacs.git
[2]: https://https.git.savannah.gnu.org/git/emacs.git?