### PR TITLE
Replace stdenv.is* with stdenv.hostPlatform.is*

### DIFF
--- a/overlays/emacs.nix
+++ b/overlays/emacs.nix
@@ -27,7 +27,7 @@ let
 
               # fixes segfaults that only occur on aarch64-linux (#264)
               configureFlags = old.configureFlags ++
-                               super.lib.optionals (super.stdenv.isLinux && super.stdenv.isAarch64)
+                               super.lib.optionals (super.stdenv.hostPlatform.isLinux && super.stdenv.hostPlatform.isAarch64)
                                  [ "--enable-check-lisp-object-type" ];
 
               postPatch = old.postPatch + ''


### PR DESCRIPTION
Fixes #547 
Checking `stdenv.isLinux` and `stdenv.isAarch64` fails on current `nixos-unstable`. This makes it build but I don't know if it will work on anything else than `nixos-unstable`