### PR TITLE
Remove project-store since it is renamed[0] to project-nix-store

### DIFF
--- a/repos/nongnu/nongnu-devel-generated.nix
+++ b/repos/nongnu/nongnu-devel-generated.nix
@@ -4826,27 +4826,6 @@
       };
     }
   ) { };
-  project-store = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "project-store";
-      ename = "project-store";
-      version = "0.9.0.0.20260820.3";
-      src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/project-store-0.9.0.0.20260820.3.tar";
-        sha256 = "0rxw7xbfqcv1rvwi7ns9f3pgvy2i72m97gblfa8ibd3wndbw31y7";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.nongnu.org/nongnu-devel/project-store.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
   projectile = callPackage (
     {
       compat,

--- a/repos/nongnu/nongnu-generated.nix
+++ b/repos/nongnu/nongnu-generated.nix
@@ -4848,27 +4848,6 @@
       };
     }
   ) { };
-  project-store = callPackage (
-    {
-      elpaBuild,
-      fetchurl,
-      lib,
-    }:
-    elpaBuild {
-      pname = "project-store";
-      ename = "project-store";
-      version = "0.9.0";
-      src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/project-store-0.9.0.tar";
-        sha256 = "0i3xfl94ad8h01z7cr3rrmxw3w70444j2yr43irnip58zqjwnf2a";
-      };
-      packageRequires = [ ];
-      meta = {
-        homepage = "https://elpa.nongnu.org/nongnu/project-store.html";
-        license = lib.licenses.free;
-      };
-    }
-  ) { };
   projectile = callPackage (
     {
       compat,


### PR DESCRIPTION
The archive-contents[1] file of NonGNU ELPA does not contain project-store any more.  However, our updater will not[2] delete packages.  So we delete it manually.

[0]: https://github.com/jian-lin/project-nix-store/pull/5
[1]: https://elpa.nongnu.org/nongnu/archive-contents
[2]: https://github.com/nix-community/emacs2nix/blob/07a858c2ca1bab4a29c69c0315d82497c8092ae9/elpa2nix.hs#L114